### PR TITLE
fix: can't teleport correctly if the player is sleeping

### DIFF
--- a/src/main/kotlin/com/github/zly2006/enclosure/EnclosureArea.kt
+++ b/src/main/kotlin/com/github/zly2006/enclosure/EnclosureArea.kt
@@ -386,6 +386,9 @@ open class EnclosureArea : PersistentState, EnclosureView {
     }
 
     fun teleport(player: ServerPlayerEntity) {
+        if (player.isSleeping) {
+            player.wakeUp()
+        }
         player.teleport(world, teleportPos!!.x, teleportPos!!.y, teleportPos!!.z, yaw, pitch)
     }
 


### PR DESCRIPTION
## Bug 描述

这个Bug的发现纯属巧合。
刚刚在SLS玩，发生了雷暴，我就回家到床上躺着，然后随便挑了个领地tp过去(tp着玩，诶嘿)，结果...我没醒，但我确实被tp过去了，但在我按下起床之后，我又回到了我家里。
我不知道在对面领地里我看起来是个什么状态？我觉得可能是我躺在地上？？？

## 修复方法

在 EnclosureArea.teleport 方法中，先检查玩家是否在睡觉，如果是，将其唤醒，然后执行tp