### PR TITLE
fix: can't undo movement of players who have a vehicle

### DIFF
--- a/src/main/kotlin/com/github/zly2006/enclosure/EnclosureArea.kt
+++ b/src/main/kotlin/com/github/zly2006/enclosure/EnclosureArea.kt
@@ -9,6 +9,7 @@ import com.github.zly2006.enclosure.utils.Serializable2Text.SerializationSetting
 import me.lucko.fabric.api.permissions.v0.Permissions
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking
+import net.minecraft.entity.Entity
 import net.minecraft.nbt.NbtCompound
 import net.minecraft.nbt.NbtDouble
 import net.minecraft.nbt.NbtList
@@ -156,7 +157,14 @@ open class EnclosureArea : PersistentState, EnclosureView {
             minecraftServer.playerManager.respawnPlayer(player, true)
             minecraftServer.overworld.chunkManager.updatePosition(player)
         } else {
-            player.teleport(world, x.toDouble(), y.toDouble(), z.toDouble(), 0f, 0f)
+            val tpTarget: Entity
+            if (player.hasVehicle()) {
+                tpTarget = player.vehicle!!
+            } else {
+                tpTarget = player
+            }
+            tpTarget.teleport(world, x.toDouble(), y.toDouble(), z.toDouble(),
+                emptySet(), 0f, 0f)
         }
     }
 


### PR DESCRIPTION
# **这个PR不能立刻合并。**

已知问题: 若玩家已在无VEHICLE权限的领地且不动，那么只有无权限消息刷屏，玩家无法被踢出领地(似乎从领地外到领地内若移动距离过短时也会发生这个问题)
我不知如何解决，恳请Steve老师不吝赐教qwq

## PR 目的

此PR旨在解决玩家在载具中时进入无VEHICLE权限的领地后离开载具而无法重新进入载具的问题

## 修复方法

阻止在载具上的玩家进入无VEHICLE权限的领地。