### PR TITLE
fix: pass the right click action on wooden hoe if pos1 is undefined yet

### DIFF
--- a/src/main/kotlin/com/github/zly2006/enclosure/listeners/SessionListener.kt
+++ b/src/main/kotlin/com/github/zly2006/enclosure/listeners/SessionListener.kt
@@ -48,7 +48,10 @@ class SessionListener private constructor() : ServerPlayConnectionEvents.Join,
         if (player.mainHandStack.item === ServerMain.operationItem && hand == Hand.MAIN_HAND || player.offHandStack.item === ServerMain.operationItem && hand == Hand.OFF_HAND) {
             if (getSession(player)!!.pos2 != hitResult.blockPos) {
                 val session = getSession(player)
-                session!!.syncDimension(player as ServerPlayerEntity)
+                if (session!!.pos1 == BlockPos.ORIGIN) {
+                    return ActionResult.PASS
+                }
+                session.syncDimension(player as ServerPlayerEntity)
                 session.pos2 = hitResult.blockPos
                 session.enable()
                 session.trySync()

--- a/src/main/kotlin/com/github/zly2006/enclosure/listeners/SessionListener.kt
+++ b/src/main/kotlin/com/github/zly2006/enclosure/listeners/SessionListener.kt
@@ -53,7 +53,11 @@ class SessionListener private constructor() : ServerPlayConnectionEvents.Join,
                 if (session!!.pos1 == BlockPos.ORIGIN) {
                     if (ServerMain.operationItem is HoeItem) {
                         when (world.getBlockState(hitResult.blockPos).block.asItem()) {
-                            Items.DIRT, Items.DIRT_PATH, Items.GRASS_BLOCK -> return ActionResult.PASS
+                            Items.DIRT,
+                            Items.DIRT_PATH,
+                            Items.ROOTED_DIRT,
+                            Items.COARSE_DIRT,
+                            Items.GRASS_BLOCK -> return ActionResult.PASS
                         }
                     }
                 }

--- a/src/main/kotlin/com/github/zly2006/enclosure/listeners/SessionListener.kt
+++ b/src/main/kotlin/com/github/zly2006/enclosure/listeners/SessionListener.kt
@@ -11,6 +11,8 @@ import net.fabricmc.fabric.api.event.player.UseBlockCallback
 import net.fabricmc.fabric.api.networking.v1.PacketSender
 import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents
 import net.minecraft.entity.player.PlayerEntity
+import net.minecraft.item.HoeItem
+import net.minecraft.item.Items
 import net.minecraft.server.MinecraftServer
 import net.minecraft.server.network.ServerPlayNetworkHandler
 import net.minecraft.server.network.ServerPlayerEntity
@@ -49,7 +51,11 @@ class SessionListener private constructor() : ServerPlayConnectionEvents.Join,
             if (getSession(player)!!.pos2 != hitResult.blockPos) {
                 val session = getSession(player)
                 if (session!!.pos1 == BlockPos.ORIGIN) {
-                    return ActionResult.PASS
+                    if (ServerMain.operationItem is HoeItem) {
+                        when (world.getBlockState(hitResult.blockPos).block.asItem()) {
+                            Items.DIRT, Items.DIRT_PATH, Items.GRASS_BLOCK -> return ActionResult.PASS
+                        }
+                    }
                 }
                 session.syncDimension(player as ServerPlayerEntity)
                 session.pos2 = hitResult.blockPos


### PR DESCRIPTION
我认为在未选定pos1时木锄应该仍然具有其原版功能。
此 PR 实现了这个。
想象一下，一个新用户用这个，结果上来发现木锄不能用了，这多少有点影响用户体验。
解决方案: 在发现右键时，如果pos1未指定，批准锄地操作。