### PR TITLE
fix: respawnPlayer() will cause the player fall into an abnormal state

### DIFF
--- a/src/main/kotlin/com/github/zly2006/enclosure/EnclosureArea.kt
+++ b/src/main/kotlin/com/github/zly2006/enclosure/EnclosureArea.kt
@@ -156,7 +156,7 @@ open class EnclosureArea : PersistentState, EnclosureView {
             val overworld = player.server.overworld
             val spawnPos = overworld.spawnPos
             player.teleport(
-                overworld, spawnPos.x.toDouble() + 0.5, spawnPos.y.toDouble() + 0.5, spawnPos.z.toDouble() + 0.5, 0f, 0f
+                overworld, spawnPos.x.toDouble() + 0.5, spawnPos.y.toDouble(), spawnPos.z.toDouble() + 0.5, 0f, 0f
             )
         } else {
             player.teleport(world, x.toDouble(), y.toDouble(), z.toDouble(), 0f, 0f)

--- a/src/main/kotlin/com/github/zly2006/enclosure/EnclosureArea.kt
+++ b/src/main/kotlin/com/github/zly2006/enclosure/EnclosureArea.kt
@@ -155,7 +155,9 @@ open class EnclosureArea : PersistentState, EnclosureView {
             // this player is alive, but in a void
             val overworld = player.server.overworld
             val spawnPos = overworld.spawnPos
-            player.teleport(overworld, spawnPos.x.toDouble(), spawnPos.y.toDouble(), spawnPos.z.toDouble(), 0f, 0f)
+            player.teleport(
+                overworld, spawnPos.x.toDouble() + 0.5, spawnPos.y.toDouble() + 0.5, spawnPos.z.toDouble() + 0.5, 0f, 0f
+            )
         } else {
             player.teleport(world, x.toDouble(), y.toDouble(), z.toDouble(), 0f, 0f)
         }

--- a/src/main/kotlin/com/github/zly2006/enclosure/EnclosureArea.kt
+++ b/src/main/kotlin/com/github/zly2006/enclosure/EnclosureArea.kt
@@ -6,7 +6,6 @@ import com.github.zly2006.enclosure.gui.EnclosureScreenHandler
 import com.github.zly2006.enclosure.network.NetworkChannels
 import com.github.zly2006.enclosure.utils.*
 import com.github.zly2006.enclosure.utils.Serializable2Text.SerializationSettings
-import me.lucko.fabric.api.permissions.v0.Permissions
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking
 import net.minecraft.nbt.NbtCompound
@@ -48,6 +47,7 @@ open class EnclosureArea : PersistentState, EnclosureView {
             }
         }
     }
+
     private var locked = false
     final override var minX by lockChecker(0)
     final override var minY by lockChecker(0)
@@ -153,8 +153,9 @@ open class EnclosureArea : PersistentState, EnclosureView {
         val y = world.getTopY(Heightmap.Type.MOTION_BLOCKING_NO_LEAVES, x, z)
         if (y == world.bottomY) {
             // this player is alive, but in a void
-            minecraftServer.playerManager.respawnPlayer(player, true)
-            minecraftServer.overworld.chunkManager.updatePosition(player)
+            val overworld = player.server.overworld
+            val spawnPos = overworld.spawnPos
+            player.teleport(overworld, spawnPos.x.toDouble(), spawnPos.y.toDouble(), spawnPos.z.toDouble(), 0f, 0f)
         } else {
             player.teleport(world, x.toDouble(), y.toDouble(), z.toDouble(), 0f, 0f)
         }


### PR DESCRIPTION
To reproduce: create a residence in void, and set global 'move' to false. Then let the PlayerManager#respawnPlayer() be called.

PlayerManager#respawnPlayer() will cause the player to fall into an abnormal state, which means that the player's real position is still no change, and the player can't break any blocks. (And then the player will be kicked because of "Flying too long", and then the player can't even join the server anymore.

To stop the abuse of PlayerManager#respawnPlayer(), and change the default solution to teleport the player to the spawn of the overworld. (This may not be the best solution, maybe a config option to set where to teleport ?)