### PR TITLE
fix java.lang.IllegalArgumentException: Not bootstrapped (called from registry ResourceKey[minecraft:root / minecraft:root])

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "fabric-loom" version "1.2-SNAPSHOT" apply false
+    id "fabric-loom" version "1.6-SNAPSHOT" apply false
     id "maven-publish"
     id "org.ajoberstar.grgit" version "4.1.0"
     id "org.jetbrains.kotlin.jvm" version "1.8.10"
@@ -109,6 +109,9 @@ dependencies {
         clean.dependsOn("${it.name}:clean")
         println("Loaded " + it.name)
     }
+
+    // Mod Menu
+    modRuntimeOnly "maven.modrinth:modmenu:7.2.2"
 }
 
 java {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx5G
 org.gradle.parallel=true
 # check these on https://fabricmc.net/develop
 # Mod Properties
-mod_version=0.3.4
+mod_version=0.3.5
 archices_preview_version=
 
 maven_group=com.github.zly2006

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,8 +12,8 @@ archives_base_name=enclosure-fabric
 rei_version = 9.1.550
 
 minecraft_version=1.20.1
-yarn_mappings=1.20.1+build.1
-loader_version=0.14.21
+yarn_mappings=1.20.1+build.10
+loader_version=0.15.10
 
 #Fabric api
-fabric_version=0.83.0+1.20.1
+fabric_version=0.92.1+1.20.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/github/zly2006/enclosure/DataUpdater.java
+++ b/src/main/java/com/github/zly2006/enclosure/DataUpdater.java
@@ -12,6 +12,7 @@ public class DataUpdater {
     private interface Updater {
         NbtCompound update(NbtCompound data);
     }
+
     static final Map<Integer, Updater> updaters = new HashMap<>() {{
         put(1, (NbtCompound compound) -> {
             if (compound.contains("tp_pos") && !compound.contains("yaw")) {
@@ -31,11 +32,11 @@ public class DataUpdater {
             return compound;
         });
     }};
+
     public static NbtCompound update(int versionBefore, NbtCompound compound) {
         if (versionBefore == 0) {
             return compound;
-        }
-        else if (updaters.get(versionBefore) != null) {
+        } else if (updaters.get(versionBefore) != null) {
             Updater updater = updaters.get(versionBefore);
             compound.getKeys().forEach(key -> {
                 if (compound.get(key) instanceof NbtCompound nbt) {
@@ -47,8 +48,7 @@ public class DataUpdater {
                 }
             });
             return compound;
-        }
-        else {
+        } else {
             throw new Error("Enclosure cannot update this version of data: " + versionBefore);
         }
     }

--- a/src/main/java/com/github/zly2006/enclosure/Enclosure.java
+++ b/src/main/java/com/github/zly2006/enclosure/Enclosure.java
@@ -23,6 +23,7 @@ public class Enclosure extends EnclosureArea {
 
     /**
      * Create an instance from nbt for a specific world.
+     *
      * @param compound the nbt compound tag
      */
     public Enclosure(NbtCompound compound, ServerWorld world) {
@@ -83,8 +84,7 @@ public class Enclosure extends EnclosureArea {
                 }
             }
             return text;
-        }
-        else {
+        } else {
             return super.serialize(settings, player);
         }
     }
@@ -108,8 +108,7 @@ public class Enclosure extends EnclosureArea {
             area.setFather(this);
             subEnclosures.addArea(area);
             markDirty();
-        }
-        else {
+        } else {
             throw new IllegalArgumentException("child must be an instance of EnclosureArea");
         }
     }

--- a/src/main/java/com/github/zly2006/enclosure/EnclosureList.kt
+++ b/src/main/java/com/github/zly2006/enclosure/EnclosureList.kt
@@ -11,84 +11,84 @@ import net.minecraft.world.PersistentState
 import java.io.File
 
 class EnclosureList(world: ServerWorld, isRoot: Boolean) : PersistentState() {
-    private val areaMap: MutableMap<String, EnclosureArea> = HashMap()
-    private val boundWorld: ServerWorld?
-    val areas = areaMap.values
+  private val areaMap: MutableMap<String, EnclosureArea> = HashMap()
+  private val boundWorld: ServerWorld?
+  val areas = areaMap.values
 
-    constructor(nbt: NbtCompound, world: ServerWorld, isRoot: Boolean) : this(world, isRoot) {
-        (nbt[ENCLOSURE_LIST_KEY] as? NbtList)?.forEach {
-            val name = (it as? NbtString)?.asString() ?: return@forEach
-            val compound = nbt[name] as? NbtCompound ?: return@forEach
-            if (compound.keys.contains(SUB_ENCLOSURES_KEY)) {
-                areaMap[name] = Enclosure(compound, world)
-            } else {
-                areaMap[name] = EnclosureArea(compound, world)
-            }
-        }
+  constructor(nbt: NbtCompound, world: ServerWorld, isRoot: Boolean) : this(world, isRoot) {
+    (nbt[ENCLOSURE_LIST_KEY] as? NbtList)?.forEach {
+      val name = (it as? NbtString)?.asString() ?: return@forEach
+      val compound = nbt[name] as? NbtCompound ?: return@forEach
+      if (compound.keys.contains(SUB_ENCLOSURES_KEY)) {
+        areaMap[name] = Enclosure(compound, world)
+      } else {
+        areaMap[name] = EnclosureArea(compound, world)
+      }
     }
+  }
 
-    init {
-        boundWorld = world
-        if (isRoot) {
-            enclosures[world.registryKey] = this
-            LOGGER.debug("Creating new enclosure list for world {}", world.registryKey.value)
-            boundWorld.chunkManager.persistentStateManager[ENCLOSURE_LIST_KEY] = this
-        }
+  init {
+    boundWorld = world
+    if (isRoot) {
+      enclosures[world.registryKey] = this
+      LOGGER.debug("Creating new enclosure list for world {}", world.registryKey.value)
+      boundWorld.chunkManager.persistentStateManager[ENCLOSURE_LIST_KEY] = this
     }
+  }
 
-    override fun writeNbt(nbt: NbtCompound): NbtCompound {
-        val list = NbtList()
-        for (area in areaMap.values) {
-            list.add(NbtString.of(area.name))
-            val compound = NbtCompound()
-            area.writeNbt(compound)
-            nbt.put(area.name, compound)
-        }
-        nbt.put(ENCLOSURE_LIST_KEY, list)
-        nbt.putInt(DATA_VERSION_KEY, DATA_VERSION)
-        return nbt
+  override fun writeNbt(nbt: NbtCompound): NbtCompound {
+    val list = NbtList()
+    for (area in areaMap.values) {
+      list.add(NbtString.of(area.name))
+      val compound = NbtCompound()
+      area.writeNbt(compound)
+      nbt.put(area.name, compound)
     }
+    nbt.put(ENCLOSURE_LIST_KEY, list)
+    nbt.putInt(DATA_VERSION_KEY, DATA_VERSION)
+    return nbt
+  }
 
-    /**
-     * 只会查找到下一级，要获取最小的领地，请使用areaOf
-     */
-    fun getArea(pos: BlockPos): EnclosureArea? {
-        for (enclosureArea in areaMap.values) {
-            if (enclosureArea.isInner(pos)) {
-                return enclosureArea
-            }
-        }
-        return null
+  /**
+   * 只会查找到下一级，要获取最小的领地，请使用areaOf
+   */
+  fun getArea(pos: BlockPos): EnclosureArea? {
+    for (enclosureArea in areaMap.values) {
+      if (enclosureArea.isInner(pos)) {
+        return enclosureArea
+      }
     }
+    return null
+  }
 
-    override fun markDirty() {
-        if (boundWorld != null) {
-            val list = getAllEnclosures(boundWorld)
-            if (list === this) {
-                isDirty = true
-            } else {
-                list.markDirty()
-            }
-        }
+  override fun markDirty() {
+    if (boundWorld != null) {
+      val list = getAllEnclosures(boundWorld)
+      if (list === this) {
+        isDirty = true
+      } else {
+        list.markDirty()
+      }
     }
+  }
 
-    fun remove(name: String): Boolean {
-        if (areaMap.containsKey(name)) {
-            areaMap.remove(name)
-            markDirty()
-            return true
-        }
-        return false
+  fun remove(name: String): Boolean {
+    if (areaMap.containsKey(name)) {
+      areaMap.remove(name)
+      markDirty()
+      return true
     }
+    return false
+  }
 
-    fun addArea(area: EnclosureArea) {
-        areaMap[area.name] = area
-        markDirty()
-    }
+  fun addArea(area: EnclosureArea) {
+    areaMap[area.name] = area
+    markDirty()
+  }
 
-    override fun save(file: File) {
-        super.save(file)
-    }
+  override fun save(file: File) {
+    super.save(file)
+  }
 }
 
 const val DATA_VERSION_KEY = "data_version"

--- a/src/main/java/com/github/zly2006/enclosure/access/LecternInventoryAccess.java
+++ b/src/main/java/com/github/zly2006/enclosure/access/LecternInventoryAccess.java
@@ -8,10 +8,12 @@ import net.minecraft.util.math.BlockPos;
 public class LecternInventoryAccess implements Inventory {
     final Inventory inventory;
     final BlockPos pos;
+
     public LecternInventoryAccess(Inventory inventory, BlockPos pos) {
         this.inventory = inventory;
         this.pos = pos;
     }
+
     public BlockPos getPos() {
         return pos;
     }

--- a/src/main/java/com/github/zly2006/enclosure/access/PlayerAccess.java
+++ b/src/main/java/com/github/zly2006/enclosure/access/PlayerAccess.java
@@ -9,21 +9,26 @@ public interface PlayerAccess {
     interface MessageProvider {
         Text get(@Nullable ServerPlayerEntity player);
     }
+
     long getLastTeleportTime();
+
     void setLastTeleportTime(long time);
+
     long getPermissionDeniedMsgTime();
+
     void setPermissionDeniedMsgTime(long time);
+
     default void sendMessageWithCD(Text text) {
         if (getPermissionDeniedMsgTime() + 1000 < System.currentTimeMillis()) {
             setPermissionDeniedMsgTime(System.currentTimeMillis());
             ((PlayerEntity) this).sendMessage(text, false);
         }
     }
+
     default void sendMessageWithCD(MessageProvider provider) {
         if (this instanceof ServerPlayerEntity) {
             sendMessageWithCD(provider.get((ServerPlayerEntity) this));
-        }
-        else {
+        } else {
             sendMessageWithCD(provider.get(null));
         }
     }

--- a/src/main/java/com/github/zly2006/enclosure/access/ServerMetadataAccess.java
+++ b/src/main/java/com/github/zly2006/enclosure/access/ServerMetadataAccess.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 
 public interface ServerMetadataAccess {
     String getModName();
+
     Version getModVersion();
 
     void setModVersion(Version version);

--- a/src/main/java/com/github/zly2006/enclosure/client/mixin/MixinServerEntry.java
+++ b/src/main/java/com/github/zly2006/enclosure/client/mixin/MixinServerEntry.java
@@ -20,10 +20,17 @@ import java.util.List;
 
 @Mixin(MultiplayerServerListWidget.ServerEntry.class)
 public class MixinServerEntry {
-    @Shadow @Final private MultiplayerScreen screen;
-    @Shadow @Final private ServerInfo server;
-    @Shadow @Final private MinecraftClient client;
+    @Shadow
+    @Final
+    private MultiplayerScreen screen;
+    @Shadow
+    @Final
+    private ServerInfo server;
+    @Shadow
+    @Final
+    private MinecraftClient client;
     Identifier NOTIFY_TEXTURE = new Identifier("realms", "textures/gui/realms/trial_icon.png");
+
     @Inject(method = "render", at = @At("RETURN"))
     private void onRender(DrawContext context, int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean hovered, float tickDelta, CallbackInfo ci) {
         ServerMetadataAccess access = (ServerMetadataAccess) server;

--- a/src/main/java/com/github/zly2006/enclosure/gui/AboutScreen.java
+++ b/src/main/java/com/github/zly2006/enclosure/gui/AboutScreen.java
@@ -31,15 +31,16 @@ public class AboutScreen extends Screen {
         textWidgets.add(new ClickableTextWidget(client, parent, Text.translatable("enclosure.about.author"), null, button -> {
         }, 5, 5, width - 20));
         textWidgets.add(new ClickableTextWidget(client, parent, Text.translatable("enclosure.about.source").formatted(Formatting.UNDERLINE), Text.translatable("enclosure.about.click_to_open"),
-            button -> ConfirmLinkScreen.open("https://github.com/zly2006/Enclosure", this, true), 5, 5, width - 20));
+                button -> ConfirmLinkScreen.open("https://github.com/zly2006/Enclosure", this, true), 5, 5, width - 20));
         textWidgets.add(new ClickableTextWidget(client, parent, Text.translatable("enclosure.about.team_page").formatted(Formatting.UNDERLINE), Text.translatable("enclosure.about.click_to_open"),
-            button -> ConfirmLinkScreen.open("https://www.starlight.cool/", this, true), 5, 5, width - 20));
+                button -> ConfirmLinkScreen.open("https://www.starlight.cool/", this, true), 5, 5, width - 20));
         textWidgets.add(new ClickableTextWidget(client, parent, Text.translatable("enclosure.about.copyright"), null,
-            button -> {}, 5, 5, width - 20));
+                button -> {
+                }, 5, 5, width - 20));
         textWidgets.add(new ClickableTextWidget(client, parent, Text.translatable("点击查看中文wiki页面").formatted(Formatting.UNDERLINE), Text.translatable("enclosure.about.click_to_open"),
-            button -> ConfirmLinkScreen.open(WIKI_ZH, this, true), 5, 5, width - 20));
+                button -> ConfirmLinkScreen.open(WIKI_ZH, this, true), 5, 5, width - 20));
         textWidgets.add(new ClickableTextWidget(client, parent, Text.translatable("Click to open English wiki page").formatted(Formatting.UNDERLINE), Text.translatable("enclosure.about.click_to_open"),
-            button -> ConfirmLinkScreen.open(WIKI_EN, this, true), 5, 5, width - 20));
+                button -> ConfirmLinkScreen.open(WIKI_EN, this, true), 5, 5, width - 20));
     }
 
     @Override

--- a/src/main/java/com/github/zly2006/enclosure/gui/ClickableTextWidget.java
+++ b/src/main/java/com/github/zly2006/enclosure/gui/ClickableTextWidget.java
@@ -44,12 +44,15 @@ public class ClickableTextWidget implements Element, Drawable, Selectable {
     int renderedWidth;
     private int height;
     final TextRenderer textRenderer;
+
     public int getHeight() {
         return height;
     }
+
     public int calcHeight() {
         return textRenderer.wrapLines(text, width).size() * (textRenderer.fontHeight + 1);
     }
+
     public ClickableTextWidget(MinecraftClient client, Screen parent, Text text, Text hover, Consumer<Integer> onClick, int x, int y, int width) {
         textRenderer = client.textRenderer;
         this.parent = parent;
@@ -61,6 +64,7 @@ public class ClickableTextWidget implements Element, Drawable, Selectable {
         this.width = width;
         height = 0;
     }
+
     @Override
     public boolean mouseClicked(double mouseX, double mouseY, int button) {
         if (mouseX >= x && mouseX <= x + renderedWidth) {

--- a/src/main/java/com/github/zly2006/enclosure/gui/ConfirmScreen.java
+++ b/src/main/java/com/github/zly2006/enclosure/gui/ConfirmScreen.java
@@ -20,20 +20,20 @@ public class ConfirmScreen extends Screen {
         this.message = message;
         this.action = action;
         yesButton = ButtonWidget.builder(Text.translatable("enclosure.widget.yes"), button -> {
-                action.run();
-                assert client != null;
-                client.setScreen(parent);
-            })
-            .position(parent.width / 2 - 95, 0)
-            .size(90, 20)
-            .build();
+                    action.run();
+                    assert client != null;
+                    client.setScreen(parent);
+                })
+                .position(parent.width / 2 - 95, 0)
+                .size(90, 20)
+                .build();
         noButton = ButtonWidget.builder(Text.translatable("enclosure.widget.no"), button -> {
-                assert client != null;
-                client.setScreen(parent);
-            })
-            .position(parent.width / 2 + 5, 0)
-            .size(90, 20)
-            .build();
+                    assert client != null;
+                    client.setScreen(parent);
+                })
+                .position(parent.width / 2 + 5, 0)
+                .size(90, 20)
+                .build();
         addDrawableChild(yesButton);
         addDrawableChild(noButton);
     }

--- a/src/main/java/com/github/zly2006/enclosure/gui/EnclosureScreen.java
+++ b/src/main/java/com/github/zly2006/enclosure/gui/EnclosureScreen.java
@@ -48,37 +48,37 @@ public class EnclosureScreen extends HandledScreen<EnclosureScreenHandler> imple
                 }).size(40, 20).build()
         ));
         globalWidget = addDrawableChild(ButtonWidget.builder(Text.translatable("enclosure.widget.global"), button -> {
-                assert client != null;
-                client.setScreen(new PermissionScreen(area, new UUID(0, 0), handler.fullName, this));
-            })
-            .size(100, 20)
-            .position(5, 35)
-            .build());
+                    assert client != null;
+                    client.setScreen(new PermissionScreen(area, new UUID(0, 0), handler.fullName, this));
+                })
+                .size(100, 20)
+                .position(5, 35)
+                .build());
         playerWidget = addDrawableChild(ButtonWidget.builder(Text.translatable("enclosure.widget.player"), button -> {
-                assert client != null;
-                button.active = false;
-                unlistedWidget.active = true;
-                permissionTargetListWidget.showPlayers();
-            })
-            .size(100, 20)
-            .position(110, 35)
-            .build());
+                    assert client != null;
+                    button.active = false;
+                    unlistedWidget.active = true;
+                    permissionTargetListWidget.showPlayers();
+                })
+                .size(100, 20)
+                .position(110, 35)
+                .build());
         unlistedWidget = addDrawableChild(ButtonWidget.builder(Text.translatable("enclosure.widget.unspecified_player"), button -> {
-                assert client != null;
-                button.active = false;
-                playerWidget.active = true;
-                permissionTargetListWidget.showUnlistedPlayers();
-            })
-            .size(100, 20)
-            .position(215, 35)
-            .build());
+                    assert client != null;
+                    button.active = false;
+                    playerWidget.active = true;
+                    permissionTargetListWidget.showUnlistedPlayers();
+                })
+                .size(100, 20)
+                .position(215, 35)
+                .build());
         aboutWidget = addDrawableChild(ButtonWidget.builder(Text.translatable("enclosure.widget.about"), button -> {
-                assert client != null;
-                client.setScreen(new AboutScreen(this));
-            })
-            .size(50, 20)
-            .position(320, 35)
-            .build());
+                    assert client != null;
+                    client.setScreen(new AboutScreen(this));
+                })
+                .size(50, 20)
+                .position(320, 35)
+                .build());
         if (area.getOwner().equals(client.player.getUuid()) || client.player.hasPermissionLevel(4)) {
             transferWidget = addDrawableChild(ButtonWidget.builder(Text.translatable("enclosure.widget.transfer"), button -> {
                 client.setScreen(new TransferScreen(area, handler.fullName, this));
@@ -88,62 +88,62 @@ public class EnclosureScreen extends HandledScreen<EnclosureScreenHandler> imple
         assert client != null;
         if (!handler.fatherFullName.isEmpty()) {
             textWidgets.add(new ClickableTextWidget(client, this, Text.literal("<<< ")
-                .styled(style -> style.withColor(Formatting.DARK_GREEN))
-                .append(Text.literal(handler.fatherFullName).formatted(Formatting.GOLD)),
-                Text.translatable("enclosure.widget.father_land.hover"),
-                button -> {
-                    assert client.player != null;
-                    close();
-                    client.player.networkHandler.sendChatCommand("enclosure gui " + handler.fatherFullName);
-                }, 5, 5, width - 10));
+                    .styled(style -> style.withColor(Formatting.DARK_GREEN))
+                    .append(Text.literal(handler.fatherFullName).formatted(Formatting.GOLD)),
+                    Text.translatable("enclosure.widget.father_land.hover"),
+                    button -> {
+                        assert client.player != null;
+                        close();
+                        client.player.networkHandler.sendChatCommand("enclosure gui " + handler.fatherFullName);
+                    }, 5, 5, width - 10));
         }
         textWidgets.add(new ClickableTextWidget(client, this, Text.empty()
-            .append(Text.literal(area.getFullName()).styled(style -> style.withColor(Formatting.GOLD)))
-            .append(" ")
-            .append(Text.translatable("enclosure.info.created_by"))
-            .append(" ")
-            .append(owner == null ?
-                Text.translatable("enclosure.message.unknown_user").styled(style -> style.withColor(Formatting.RED)) :
-                Text.literal(owner).styled(style -> style.withColor(Formatting.GOLD)))
-            .append(", ")
-            .append(Text.translatable("enclosure.info.created_on"))
-            .append(Text.literal(new SimpleDateFormat().format(area.getCreatedOn())).styled(style -> style.withColor(Formatting.GOLD))),
-            null, null,
-            5, 5, width - 10));
+                .append(Text.literal(area.getFullName()).styled(style -> style.withColor(Formatting.GOLD)))
+                .append(" ")
+                .append(Text.translatable("enclosure.info.created_by"))
+                .append(" ")
+                .append(owner == null ?
+                        Text.translatable("enclosure.message.unknown_user").styled(style -> style.withColor(Formatting.RED)) :
+                        Text.literal(owner).styled(style -> style.withColor(Formatting.GOLD)))
+                .append(", ")
+                .append(Text.translatable("enclosure.info.created_on"))
+                .append(Text.literal(new SimpleDateFormat().format(area.getCreatedOn())).styled(style -> style.withColor(Formatting.GOLD))),
+                null, null,
+                5, 5, width - 10));
         textWidgets.add(new ClickableTextWidget(client, this, Text.translatable("enclosure.message.select.from")
-            .append(Text.literal("[").styled(style -> style.withColor(Formatting.DARK_GREEN)))
-            .append(Text.literal(String.valueOf(area.getMinX())).styled(style -> style.withColor(Formatting.GREEN)))
-            .append(Text.literal(", ").styled(style -> style.withColor(Formatting.DARK_GREEN)))
-            .append(Text.literal(String.valueOf(area.getMinY())).styled(style -> style.withColor(Formatting.GREEN)))
-            .append(Text.literal(", ").styled(style -> style.withColor(Formatting.DARK_GREEN)))
-            .append(Text.literal(String.valueOf(area.getMinZ())).styled(style -> style.withColor(Formatting.GREEN)))
-            .append(Text.literal("]").styled(style -> style.withColor(Formatting.DARK_GREEN)))
-            .append(Text.translatable("enclosure.message.select.to"))
-            .append(Text.literal("[").styled(style -> style.withColor(Formatting.DARK_GREEN)))
-            .append(Text.literal(String.valueOf(area.getMaxX())).styled(style -> style.withColor(Formatting.GREEN)))
-            .append(Text.literal(", ").styled(style -> style.withColor(Formatting.DARK_GREEN)))
-            .append(Text.literal(String.valueOf(area.getMaxY())).styled(style -> style.withColor(Formatting.GREEN)))
-            .append(Text.literal(", ").styled(style -> style.withColor(Formatting.DARK_GREEN)))
-            .append(Text.literal(String.valueOf(area.getMaxZ())).styled(style -> style.withColor(Formatting.GREEN)))
-            .append(Text.literal("]").styled(style -> style.withColor(Formatting.DARK_GREEN)))
-            .append(Text.translatable("enclosure.message.select.world"))
-            .append(Text.literal(handler.worldId.toString()).styled(style -> style.withColor(Formatting.GOLD))),
-            Text.translatable("enclosure.widget.selection_render.hover"),
-            button -> {
-                assert client.player != null;
-                client.player.networkHandler.sendChatCommand("enclosure select land " + handler.fullName);
-                close();
-            }, 5, 20, width - 10));
-        for (String name : handler.subAreaNames) {
-            subLandWidgets.add(new ClickableTextWidget(client, this, Text.literal(">>> ")
-                .styled(style -> style.withColor(Formatting.DARK_GREEN))
-                .append(Text.literal(name).formatted(Formatting.GOLD)),
-                Text.translatable("enclosure.widget.sub_land.hover"),
+                .append(Text.literal("[").styled(style -> style.withColor(Formatting.DARK_GREEN)))
+                .append(Text.literal(String.valueOf(area.getMinX())).styled(style -> style.withColor(Formatting.GREEN)))
+                .append(Text.literal(", ").styled(style -> style.withColor(Formatting.DARK_GREEN)))
+                .append(Text.literal(String.valueOf(area.getMinY())).styled(style -> style.withColor(Formatting.GREEN)))
+                .append(Text.literal(", ").styled(style -> style.withColor(Formatting.DARK_GREEN)))
+                .append(Text.literal(String.valueOf(area.getMinZ())).styled(style -> style.withColor(Formatting.GREEN)))
+                .append(Text.literal("]").styled(style -> style.withColor(Formatting.DARK_GREEN)))
+                .append(Text.translatable("enclosure.message.select.to"))
+                .append(Text.literal("[").styled(style -> style.withColor(Formatting.DARK_GREEN)))
+                .append(Text.literal(String.valueOf(area.getMaxX())).styled(style -> style.withColor(Formatting.GREEN)))
+                .append(Text.literal(", ").styled(style -> style.withColor(Formatting.DARK_GREEN)))
+                .append(Text.literal(String.valueOf(area.getMaxY())).styled(style -> style.withColor(Formatting.GREEN)))
+                .append(Text.literal(", ").styled(style -> style.withColor(Formatting.DARK_GREEN)))
+                .append(Text.literal(String.valueOf(area.getMaxZ())).styled(style -> style.withColor(Formatting.GREEN)))
+                .append(Text.literal("]").styled(style -> style.withColor(Formatting.DARK_GREEN)))
+                .append(Text.translatable("enclosure.message.select.world"))
+                .append(Text.literal(handler.worldId.toString()).styled(style -> style.withColor(Formatting.GOLD))),
+                Text.translatable("enclosure.widget.selection_render.hover"),
                 button -> {
                     assert client.player != null;
+                    client.player.networkHandler.sendChatCommand("enclosure select land " + handler.fullName);
                     close();
-                    client.player.networkHandler.sendChatCommand("enclosure gui %s.%s".formatted(handler.fullName, name));
-                }, 5, 5, 0));
+                }, 5, 20, width - 10));
+        for (String name : handler.subAreaNames) {
+            subLandWidgets.add(new ClickableTextWidget(client, this, Text.literal(">>> ")
+                    .styled(style -> style.withColor(Formatting.DARK_GREEN))
+                    .append(Text.literal(name).formatted(Formatting.GOLD)),
+                    Text.translatable("enclosure.widget.sub_land.hover"),
+                    button -> {
+                        assert client.player != null;
+                        close();
+                        client.player.networkHandler.sendChatCommand("enclosure gui %s.%s".formatted(handler.fullName, name));
+                    }, 5, 5, 0));
         }
     }
 
@@ -179,8 +179,7 @@ public class EnclosureScreen extends HandledScreen<EnclosureScreenHandler> imple
         if (transferWidget != null) {
             transferWidget.setY(renderBottom + 20);
             permissionTargetListWidget.setTop(renderBottom + 45);
-        }
-        else {
+        } else {
             permissionTargetListWidget.setTop(renderBottom + 25);
         }
         super.render(context, mouseX, mouseY, delta);
@@ -204,7 +203,8 @@ public class EnclosureScreen extends HandledScreen<EnclosureScreenHandler> imple
     }
 
     @Override
-    protected void drawForeground(DrawContext context, int mouseX, int mouseY) { }
+    protected void drawForeground(DrawContext context, int mouseX, int mouseY) {
+    }
 
     @Override
     public boolean keyPressed(int keyCode, int scanCode, int modifiers) {

--- a/src/main/java/com/github/zly2006/enclosure/gui/EnclosureScreenHandler.java
+++ b/src/main/java/com/github/zly2006/enclosure/gui/EnclosureScreenHandler.java
@@ -27,20 +27,20 @@ import java.util.List;
 public class EnclosureScreenHandler extends ScreenHandler {
     public static final Identifier ENCLOSURE_SCREEN_ID = new Identifier("enclosure", "screen.enclosure");
     public static final ExtendedScreenHandlerType<EnclosureScreenHandler> ENCLOSURE_SCREEN_HANDLER =
-        new ExtendedScreenHandlerType<>((syncId, inventory, buf) -> {
-            String fullName = buf.readString();
-            String fatherFullName = buf.readString();
-            Identifier worldId = buf.readIdentifier();
-            NbtCompound compound = buf.readNbt();
-            assert compound != null;
-            EnclosureView.ReadOnly area = EnclosureView.ReadOnly.Companion.readonly(compound);
-            List<String> subAreaNames = new ArrayList<>();
-            int size = buf.readVarInt();
-            for (int i = 0; i < size; i++) {
-                subAreaNames.add(buf.readString());
-            }
-            return new EnclosureScreenHandler(syncId, area, fullName, fatherFullName, worldId, subAreaNames);
-        });
+            new ExtendedScreenHandlerType<>((syncId, inventory, buf) -> {
+                String fullName = buf.readString();
+                String fatherFullName = buf.readString();
+                Identifier worldId = buf.readIdentifier();
+                NbtCompound compound = buf.readNbt();
+                assert compound != null;
+                EnclosureView.ReadOnly area = EnclosureView.ReadOnly.Companion.readonly(compound);
+                List<String> subAreaNames = new ArrayList<>();
+                int size = buf.readVarInt();
+                for (int i = 0; i < size; i++) {
+                    subAreaNames.add(buf.readString());
+                }
+                return new EnclosureScreenHandler(syncId, area, fullName, fatherFullName, worldId, subAreaNames);
+            });
     public final EnclosureView.ReadOnly area;
     public final String fullName;
     public final String fatherFullName;
@@ -72,43 +72,43 @@ public class EnclosureScreenHandler extends ScreenHandler {
 
     public static void open(@NotNull ServerPlayerEntity player, @NotNull EnclosureArea area) {
         player.openHandledScreen(new ExtendedScreenHandlerFactory() {
-                @Override
-                public void writeScreenOpeningData(ServerPlayerEntity player, PacketByteBuf buf) {
-                    buf.writeString(area.getFullName());
-                    if (area.getFather() instanceof Enclosure) {
-                        buf.writeString(area.getFather().getFullName());
-                    } else if (area.getFather() != null) {
-                        buf.writeString("$" + area.getFather().getFullName());
-                    } else {
-                        buf.writeString("");
-                    }
-                    buf.writeIdentifier(area.getWorld().getRegistryKey().getValue());
-                    NbtCompound compound = new NbtCompound();
-                    area.writeNbt(compound);
-                    buf.writeNbt(compound);
-                    if (area instanceof Enclosure enclosure) {
-                        buf.writeVarInt(enclosure.getSubEnclosures().getAreas().size());
-                        for (EnclosureArea subArea : enclosure.getSubEnclosures().getAreas()) {
-                            buf.writeString(subArea.getName());
-                        }
-                    } else {
-                        buf.writeVarInt(0);
-                    }
+            @Override
+            public void writeScreenOpeningData(ServerPlayerEntity player, PacketByteBuf buf) {
+                buf.writeString(area.getFullName());
+                if (area.getFather() instanceof Enclosure) {
+                    buf.writeString(area.getFather().getFullName());
+                } else if (area.getFather() != null) {
+                    buf.writeString("$" + area.getFather().getFullName());
+                } else {
+                    buf.writeString("");
                 }
-
-                @Override
-                public Text getDisplayName() {
-                    return area.serialize(Serializable2Text.SerializationSettings.Name, player);
+                buf.writeIdentifier(area.getWorld().getRegistryKey().getValue());
+                NbtCompound compound = new NbtCompound();
+                area.writeNbt(compound);
+                buf.writeNbt(compound);
+                if (area instanceof Enclosure enclosure) {
+                    buf.writeVarInt(enclosure.getSubEnclosures().getAreas().size());
+                    for (EnclosureArea subArea : enclosure.getSubEnclosures().getAreas()) {
+                        buf.writeString(subArea.getName());
+                    }
+                } else {
+                    buf.writeVarInt(0);
                 }
+            }
 
-                @Nullable
-                @Override
-                public ScreenHandler createMenu(int syncId, PlayerInventory inv, PlayerEntity player) {
-                    PacketByteBuf buf = PacketByteBufs.create();
-                    writeScreenOpeningData(null, buf);
-                    return EnclosureScreenHandler.ENCLOSURE_SCREEN_HANDLER
+            @Override
+            public Text getDisplayName() {
+                return area.serialize(Serializable2Text.SerializationSettings.Name, player);
+            }
+
+            @Nullable
+            @Override
+            public ScreenHandler createMenu(int syncId, PlayerInventory inv, PlayerEntity player) {
+                PacketByteBuf buf = PacketByteBufs.create();
+                writeScreenOpeningData(null, buf);
+                return EnclosureScreenHandler.ENCLOSURE_SCREEN_HANDLER
                         .create(syncId, inv, buf);
-                }
-            });
+            }
+        });
     }
 }

--- a/src/main/java/com/github/zly2006/enclosure/gui/PermissionListWidget.java
+++ b/src/main/java/com/github/zly2006/enclosure/gui/PermissionListWidget.java
@@ -25,6 +25,7 @@ import java.util.*;
 import java.util.function.Supplier;
 
 import static com.github.zly2006.enclosure.command.EnclosureCommandKt.CONSOLE;
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
 
 public class PermissionListWidget extends ElementListWidget<PermissionListWidget.Entry> {
     private final Screen parent;
@@ -42,7 +43,7 @@ public class PermissionListWidget extends ElementListWidget<PermissionListWidget
         this.uuid = uuid;
         this.target = uuid.equals(CONSOLE) ? Permission.Target.Enclosure : Permission.Target.Player;
         addEntry(new SearchEntry());
-        Permission.PERMISSIONS.values().stream().filter(permission ->
+        permissions.PERMISSIONS.values().stream().filter(permission ->
                         (permission.getTarget().fitPlayer() && target.fitPlayer()) ||
                                 (permission.getTarget().fitEnclosure() && target.fitEnclosure()))
                 .sorted(Comparator.comparing(Permission::getName))
@@ -67,7 +68,8 @@ public class PermissionListWidget extends ElementListWidget<PermissionListWidget
     }
 
     @Environment(EnvType.CLIENT)
-    public abstract static class Entry extends ElementListWidget.Entry<Entry> { }
+    public abstract static class Entry extends ElementListWidget.Entry<Entry> {
+    }
 
     @Environment(EnvType.CLIENT)
     public class PermissionEntry extends Entry {
@@ -77,8 +79,9 @@ public class PermissionListWidget extends ElementListWidget<PermissionListWidget
         private Text value(Boolean value) {
             return value == null ? Text.translatable("enclosure.widget.none").setStyle(Style.EMPTY.withColor(Formatting.DARK_AQUA))
                     : value ? Text.translatable("enclosure.widget.true").setStyle(Style.EMPTY.withColor(Formatting.GREEN))
-                            : Text.translatable("enclosure.widget.false").setStyle(Style.EMPTY.withColor(Formatting.RED));
+                    : Text.translatable("enclosure.widget.false").setStyle(Style.EMPTY.withColor(Formatting.RED));
         }
+
         private Text value() {
             return value(getValue());
         }
@@ -95,7 +98,8 @@ public class PermissionListWidget extends ElementListWidget<PermissionListWidget
 
         public PermissionEntry(Permission permission) {
             this.permission = permission;
-            buttonWidget = new SetButtonWidget(0, 0, 40, 20, value(), buttonWidget -> {}, Supplier::get);
+            buttonWidget = new SetButtonWidget(0, 0, 40, 20, value(), buttonWidget -> {
+            }, Supplier::get);
         }
 
         @Override
@@ -123,8 +127,7 @@ public class PermissionListWidget extends ElementListWidget<PermissionListWidget
                         Text.translatable("enclosure.widget.click.left").styled(style -> style.withColor(Formatting.GREEN)),
                         Text.translatable("enclosure.widget.click.right").styled(style -> style.withColor(Formatting.RED))
                 ), mouseX, mouseY);
-            }
-            else if (hovered) {
+            } else if (hovered) {
                 context.drawTooltip(client.textRenderer,
                         List.of(permission.getDescription(),
                                 Text.translatable("enclosure.widget.default_value_is").setStyle(Style.EMPTY.withColor(Formatting.GOLD))
@@ -143,27 +146,25 @@ public class PermissionListWidget extends ElementListWidget<PermissionListWidget
                 assert client.player != null;
                 if (!visible || !active) {
                     return false;
-                }
-                else if (button == GLFW.GLFW_MOUSE_BUTTON_LEFT) {
+                } else if (button == GLFW.GLFW_MOUSE_BUTTON_LEFT) {
                     Boolean value = getValue();
                     if (value == null) setValue(true);
                     else setValue(null);
 
                     client.player.networkHandler.sendChatCommand("enclosure set " + fullName + " uuid " +
-                        uuid.toString() + " " +
-                        permission.getName() + " " +
-                        Optional.ofNullable(getValue()).map(String::valueOf).orElse("none"));
+                            uuid.toString() + " " +
+                            permission.getName() + " " +
+                            Optional.ofNullable(getValue()).map(String::valueOf).orElse("none"));
                     buttonWidget.setMessage(value());
                     return true;
-                }
-                else if (button == GLFW.GLFW_MOUSE_BUTTON_RIGHT) {
+                } else if (button == GLFW.GLFW_MOUSE_BUTTON_RIGHT) {
                     Boolean value = getValue();
                     if (value == null) setValue(false);
                     else setValue(null);
                     client.player.networkHandler.sendChatCommand("enclosure set " + fullName + " uuid " +
-                        uuid.toString() + " " +
-                        permission.getName() + " " +
-                        Optional.ofNullable(getValue()).map(String::valueOf).orElse("none"));
+                            uuid.toString() + " " +
+                            permission.getName() + " " +
+                            Optional.ofNullable(getValue()).map(String::valueOf).orElse("none"));
                     buttonWidget.setMessage(value());
                     return true;
                 }
@@ -181,7 +182,7 @@ public class PermissionListWidget extends ElementListWidget<PermissionListWidget
             searchWidget.setChangedListener(s -> {
                 clearEntries();
                 addEntry(this);
-                Permission.PERMISSIONS.values().stream().filter(permission ->
+                permissions.PERMISSIONS.values().stream().filter(permission ->
                                 (permission.getTarget().fitPlayer() && target.fitPlayer()) ||
                                         (permission.getTarget().fitEnclosure() && target.fitEnclosure()))
                         .filter(permission -> {

--- a/src/main/java/com/github/zly2006/enclosure/gui/PermissionScreen.java
+++ b/src/main/java/com/github/zly2006/enclosure/gui/PermissionScreen.java
@@ -24,6 +24,7 @@ public class PermissionScreen extends Screen implements EnclosureGui {
     final String fullName;
     final Screen parent;
     PermissionListWidget permissionWidgetList;
+
     public PermissionScreen(EnclosureView.ReadOnly area, UUID uuid, String fullName, Screen parent) {
         super(Text.of("Set permission"));
         this.area = area;
@@ -67,8 +68,7 @@ public class PermissionScreen extends Screen implements EnclosureGui {
         MutableText title = Text.translatable("enclosure.widget.set_permission").append(" ");
         if (CONSOLE.equals(uuid)) {
             title.append(Text.translatable("enclosure.widget.global"));
-        }
-        else {
+        } else {
             title.append(Text.translatable("enclosure.widget.player"))
                     .append(" ")
                     .append(UUIDCacheS2CPacket.getName(uuid));

--- a/src/main/java/com/github/zly2006/enclosure/gui/PermissionTargetListWidget.java
+++ b/src/main/java/com/github/zly2006/enclosure/gui/PermissionTargetListWidget.java
@@ -35,6 +35,7 @@ public class PermissionTargetListWidget<T extends ButtonWidget> extends ElementL
         Players,
         Unspecified,
     }
+
     Mode mode = Mode.Players;
     final SearchEntry searchEntry = new SearchEntry();
 
@@ -86,7 +87,9 @@ public class PermissionTargetListWidget<T extends ButtonWidget> extends ElementL
         this.top = top;
     }
 
-    abstract static class Entry extends ElementListWidget.Entry<Entry> { }
+    abstract static class Entry extends ElementListWidget.Entry<Entry> {
+    }
+
     class PlayerEntry extends Entry {
         final Text name;
         final UUID uuid;
@@ -122,6 +125,7 @@ public class PermissionTargetListWidget<T extends ButtonWidget> extends ElementL
                     });
         }
     }
+
     @Environment(EnvType.CLIENT)
     public class SearchEntry extends Entry {
         final TextFieldWidget searchWidget;

--- a/src/main/java/com/github/zly2006/enclosure/gui/TransferScreen.java
+++ b/src/main/java/com/github/zly2006/enclosure/gui/TransferScreen.java
@@ -15,6 +15,7 @@ public class TransferScreen extends Screen implements EnclosureGui {
     private final Screen parent;
     EnclosureView.ReadOnly data;
     private PermissionTargetListWidget<ButtonWidget> permissionTargetListWidget;
+
     public TransferScreen(EnclosureView.ReadOnly data, String fullName, Screen parent) {
         super(Text.literal("Transfer"));
         this.fullName = fullName;

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinAbstractDecorationEntity.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinAbstractDecorationEntity.java
@@ -1,6 +1,5 @@
 package com.github.zly2006.enclosure.mixin;
 
-import com.github.zly2006.enclosure.utils.Permission;
 import com.github.zly2006.enclosure.utils.Utils;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
@@ -12,6 +11,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
+
 @Mixin(AbstractDecorationEntity.class)
 public abstract class MixinAbstractDecorationEntity extends Entity {
     public MixinAbstractDecorationEntity(EntityType<?> type, World world) {
@@ -20,7 +21,7 @@ public abstract class MixinAbstractDecorationEntity extends Entity {
 
     @Inject(method = "damage", at = @At("HEAD"), cancellable = true)
     private void onDamage(DamageSource source, float amount, CallbackInfoReturnable<Boolean> cir) {
-        if (!Utils.commonOnDamage(source, getBlockPos(), getWorld(), Permission.BREAK_BLOCK)) {
+        if (!Utils.commonOnDamage(source, getBlockPos(), getWorld(), permissions.BREAK_BLOCK)) {
             cir.setReturnValue(false);
         }
     }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinAbstractMinecartEntity.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinAbstractMinecartEntity.java
@@ -1,6 +1,5 @@
 package com.github.zly2006.enclosure.mixin;
 
-import com.github.zly2006.enclosure.utils.Permission;
 import com.github.zly2006.enclosure.utils.Utils;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
@@ -12,6 +11,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
+
 @Mixin(AbstractMinecartEntity.class)
 public abstract class MixinAbstractMinecartEntity extends Entity {
     protected MixinAbstractMinecartEntity(EntityType<?> entityType, World world) {
@@ -20,7 +21,7 @@ public abstract class MixinAbstractMinecartEntity extends Entity {
 
     @Inject(method = "damage", at = @At("HEAD"), cancellable = true)
     private void onDamage(DamageSource source, float amount, CallbackInfoReturnable<Boolean> cir) {
-        if (!Utils.commonOnDamage(source, getBlockPos(), getWorld(), Permission.VEHICLE)) {
+        if (!Utils.commonOnDamage(source, getBlockPos(), getWorld(), permissions.VEHICLE)) {
             cir.setReturnValue(false);
         }
     }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinAbstractSignBlock.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinAbstractSignBlock.java
@@ -2,7 +2,6 @@ package com.github.zly2006.enclosure.mixin;
 
 import com.github.zly2006.enclosure.EnclosureArea;
 import com.github.zly2006.enclosure.ServerMain;
-import com.github.zly2006.enclosure.utils.Permission;
 import net.minecraft.block.AbstractSignBlock;
 import net.minecraft.block.entity.SignBlockEntity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -13,6 +12,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
+
 @Mixin(AbstractSignBlock.class)
 public class MixinAbstractSignBlock {
     @Inject(method = "openEditScreen", at = @At("HEAD"), cancellable = true)
@@ -20,8 +21,8 @@ public class MixinAbstractSignBlock {
         if (player instanceof ServerPlayerEntity) {
             @SuppressWarnings("DataFlowIssue")
             EnclosureArea area = ServerMain.INSTANCE.getSmallestEnclosure((ServerWorld) blockEntity.getWorld(), blockEntity.getPos());
-            if (area != null && !area.hasPerm((ServerPlayerEntity) player, Permission.EDIT_SIGN)) {
-                player.sendMessage(Permission.EDIT_SIGN.getNoPermissionMsg(player));
+            if (area != null && !area.hasPerm((ServerPlayerEntity) player, permissions.EDIT_SIGN)) {
+                player.sendMessage(permissions.EDIT_SIGN.getNoPermissionMsg(player));
                 ci.cancel();
             }
         }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinAnimalEntity.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinAnimalEntity.java
@@ -16,7 +16,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import static com.github.zly2006.enclosure.utils.Permission.FEED_ANIMAL;
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
 
 @Mixin(AnimalEntity.class)
 public abstract class MixinAnimalEntity extends Entity {
@@ -38,8 +38,8 @@ public abstract class MixinAnimalEntity extends Entity {
             return;
         }
         EnclosureArea area = ServerMain.INSTANCE.getSmallestEnclosure((ServerWorld) this.getWorld(), getBlockPos());
-        if (area != null && !area.hasPerm((ServerPlayerEntity) player, FEED_ANIMAL)) {
-            player.sendMessage(FEED_ANIMAL.getNoPermissionMsg(player));
+        if (area != null && !area.hasPerm((ServerPlayerEntity) player, permissions.FEED_ANIMAL)) {
+            player.sendMessage(permissions.FEED_ANIMAL.getNoPermissionMsg(player));
             cir.setReturnValue(ActionResult.FAIL);
         }
     }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinArmorStandEntity.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinArmorStandEntity.java
@@ -1,6 +1,5 @@
 package com.github.zly2006.enclosure.mixin;
 
-import com.github.zly2006.enclosure.utils.Permission;
 import com.github.zly2006.enclosure.utils.Utils;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
@@ -12,6 +11,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
+
 @Mixin(ArmorStandEntity.class)
 public abstract class MixinArmorStandEntity extends LivingEntity {
     protected MixinArmorStandEntity(EntityType<? extends LivingEntity> entityType, World world) {
@@ -20,7 +21,7 @@ public abstract class MixinArmorStandEntity extends LivingEntity {
 
     @Inject(method = "damage", at = @At("HEAD"), cancellable = true)
     private void onDamage(DamageSource source, float amount, CallbackInfoReturnable<Boolean> cir) {
-        if (!Utils.commonOnDamage(source, getBlockPos(), getWorld(), Permission.BREAK_BLOCK)) {
+        if (!Utils.commonOnDamage(source, getBlockPos(), getWorld(), permissions.BREAK_BLOCK)) {
             cir.setReturnValue(false);
         }
     }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinBlockItem.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinBlockItem.java
@@ -1,7 +1,6 @@
 package com.github.zly2006.enclosure.mixin;
 
 import com.github.zly2006.enclosure.ServerMain;
-import com.github.zly2006.enclosure.utils.Permission;
 import net.minecraft.block.BlockState;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.ItemPlacementContext;
@@ -11,15 +10,15 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import static com.github.zly2006.enclosure.utils.Permission.PLACE_BLOCK;
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
 
 @Mixin(BlockItem.class)
 public class MixinBlockItem {
     @Inject(method = "canPlace", at = @At("HEAD"), cancellable = true)
     private void canPlace(ItemPlacementContext context, BlockState state, CallbackInfoReturnable<Boolean> cir) {
         if (context.getPlayer() instanceof ServerPlayerEntity serverPlayer) {
-            if (!ServerMain.INSTANCE.checkPermission(serverPlayer, Permission.PLACE_BLOCK, context.getBlockPos())) {
-                serverPlayer.sendMessage(PLACE_BLOCK.getNoPermissionMsg(serverPlayer));
+            if (!ServerMain.INSTANCE.checkPermission(serverPlayer, permissions.PLACE_BLOCK, context.getBlockPos())) {
+                serverPlayer.sendMessage(permissions.PLACE_BLOCK.getNoPermissionMsg(serverPlayer));
                 cir.setReturnValue(false);
             }
         }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinBoatEntity.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinBoatEntity.java
@@ -15,7 +15,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import static com.github.zly2006.enclosure.utils.Permission.VEHICLE;
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
 
 @Mixin(BoatEntity.class)
 public abstract class MixinBoatEntity extends Entity {
@@ -25,15 +25,15 @@ public abstract class MixinBoatEntity extends Entity {
 
     @Inject(method = "damage", at = @At("HEAD"), cancellable = true)
     private void onDamage(DamageSource source, float amount, CallbackInfoReturnable<Boolean> cir) {
-        if (!Utils.commonOnDamage(source, getBlockPos(), getWorld(), VEHICLE)) {
+        if (!Utils.commonOnDamage(source, getBlockPos(), getWorld(), permissions.VEHICLE)) {
             cir.setReturnValue(false);
         }
     }
 
     @Inject(method = "interact", at = @At("HEAD"), cancellable = true)
     private void onInteract(PlayerEntity player, Hand hand, CallbackInfoReturnable<ActionResult> cir) {
-        if (!ServerMain.INSTANCE.checkPermission(getWorld(), getBlockPos(), player, VEHICLE)) {
-            player.sendMessage(VEHICLE.getNoPermissionMsg(player));
+        if (!ServerMain.INSTANCE.checkPermission(getWorld(), getBlockPos(), player, permissions.VEHICLE)) {
+            player.sendMessage(permissions.VEHICLE.getNoPermissionMsg(player));
             cir.setReturnValue(ActionResult.FAIL);
         }
     }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinBowItem.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinBowItem.java
@@ -11,15 +11,16 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import static com.github.zly2006.enclosure.utils.Permission.SHOOT;
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
+
 
 @Mixin(BowItem.class)
 public class MixinBowItem {
     @Inject(at = @At("HEAD"), method = "onStoppedUsing", cancellable = true)
     public void checkBowPermission(ItemStack stack, World world, LivingEntity user, int remainingUseTicks, CallbackInfo ci) {
         if (user instanceof ServerPlayerEntity player) {
-            if (!ServerMain.INSTANCE.checkPermission(player, SHOOT, player.getBlockPos())) {
-                player.sendMessage(SHOOT.getNoPermissionMsg(player));
+            if (!ServerMain.INSTANCE.checkPermission(player, permissions.SHOOT, player.getBlockPos())) {
+                player.sendMessage(permissions.SHOOT.getNoPermissionMsg(player));
                 player.currentScreenHandler.syncState();  // update player's inventory
                 ci.cancel();
             }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinBucketItem.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinBucketItem.java
@@ -22,14 +22,18 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
+
 @Mixin(BucketItem.class)
 public class MixinBucketItem {
-    @Shadow @Final private Fluid fluid;
+    @Shadow
+    @Final
+    private Fluid fluid;
 
     @Inject(method = "use", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;canPlayerModifyAt(Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/util/math/BlockPos;)Z"), locals = LocalCapture.CAPTURE_FAILSOFT, cancellable = true)
     private void onUse(World world, PlayerEntity user, Hand hand, CallbackInfoReturnable<TypedActionResult<ItemStack>> cir, ItemStack itemStack, BlockHitResult blockHitResult, BlockPos blockPos, Direction direction, BlockPos blockPos2) {
         if (user instanceof ServerPlayerEntity player) {
-            Permission permission = this.fluid == Fluids.EMPTY ? Permission.BREAK_BLOCK : Permission.PLACE_BLOCK;
+            Permission permission = this.fluid == Fluids.EMPTY ? permissions.BREAK_BLOCK : permissions.PLACE_BLOCK;
             if (!ServerMain.INSTANCE.checkPermission(world, blockPos, player, permission) ||
                     !ServerMain.INSTANCE.checkPermission(world, blockPos2, player, permission)) {
                 player.currentScreenHandler.syncState();

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinCampfireBlock.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinCampfireBlock.java
@@ -3,7 +3,6 @@ package com.github.zly2006.enclosure.mixin;
 import com.github.zly2006.enclosure.EnclosureArea;
 import com.github.zly2006.enclosure.EnclosureList;
 import com.github.zly2006.enclosure.ServerMain;
-import com.github.zly2006.enclosure.utils.Permission;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.CampfireBlock;
 import net.minecraft.entity.Entity;
@@ -22,22 +21,24 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import static com.github.zly2006.enclosure.utils.Permission.USE_CAMPFIRE;
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
 import static net.minecraft.block.CampfireBlock.WATERLOGGED;
 
 @Mixin(CampfireBlock.class)
 public class MixinCampfireBlock {
 
-    @Shadow @Final public static BooleanProperty LIT;
+    @Shadow
+    @Final
+    public static BooleanProperty LIT;
 
     @Inject(at = @At("HEAD"), method = "extinguish", cancellable = true)
-    private static void onExtinguish(Entity entity, WorldAccess world, BlockPos pos, BlockState state, CallbackInfo ci){
-        if(world instanceof ServerWorld){
+    private static void onExtinguish(Entity entity, WorldAccess world, BlockPos pos, BlockState state, CallbackInfo ci) {
+        if (world instanceof ServerWorld) {
             EnclosureList list = ServerMain.INSTANCE.getAllEnclosures((ServerWorld) world);
             EnclosureArea area = list.getArea(pos);
-            if (area != null && !area.areaOf(pos).hasPubPerm(Permission.USE_CAMPFIRE)) {
-                if(entity instanceof ServerPlayerEntity player){
-                    player.sendMessage(USE_CAMPFIRE.getNoPermissionMsg(player));
+            if (area != null && !area.areaOf(pos).hasPubPerm(permissions.USE_CAMPFIRE)) {
+                if (entity instanceof ServerPlayerEntity player) {
+                    player.sendMessage(permissions.USE_CAMPFIRE.getNoPermissionMsg(player));
                 }
 
                 world.setBlockState(pos, state.with(WATERLOGGED, false).with(LIT, true), 252);
@@ -49,11 +50,11 @@ public class MixinCampfireBlock {
     }
 
     @Inject(at = @At("HEAD"), method = "tryFillWithFluid", cancellable = true)
-    private void onFillWithFluid(WorldAccess world, BlockPos pos, BlockState state, FluidState fluidState, CallbackInfoReturnable<Boolean> cir){
-        if(world instanceof ServerWorld){
+    private void onFillWithFluid(WorldAccess world, BlockPos pos, BlockState state, FluidState fluidState, CallbackInfoReturnable<Boolean> cir) {
+        if (world instanceof ServerWorld) {
             EnclosureList list = ServerMain.INSTANCE.getAllEnclosures((ServerWorld) world);
             EnclosureArea area = list.getArea(pos);
-            if (area != null && !area.areaOf(pos).hasPubPerm(Permission.USE_CAMPFIRE)) {
+            if (area != null && !area.areaOf(pos).hasPubPerm(permissions.USE_CAMPFIRE)) {
                 cir.setReturnValue(false);
             }
         }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinChestBoatEntity.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinChestBoatEntity.java
@@ -2,7 +2,6 @@ package com.github.zly2006.enclosure.mixin;
 
 import com.github.zly2006.enclosure.EnclosureArea;
 import com.github.zly2006.enclosure.ServerMain;
-import com.github.zly2006.enclosure.utils.Permission;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.vehicle.BoatEntity;
@@ -17,8 +16,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import static com.github.zly2006.enclosure.utils.Permission.CONTAINER;
-import static com.github.zly2006.enclosure.utils.Permission.VEHICLE;
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
 
 @Mixin(ChestBoatEntity.class)
 public class MixinChestBoatEntity extends BoatEntity {
@@ -30,12 +28,12 @@ public class MixinChestBoatEntity extends BoatEntity {
     private void canPlayerUse(PlayerEntity player, CallbackInfoReturnable<Boolean> cir) {
         if (player instanceof ServerPlayerEntity serverPlayer) {
             EnclosureArea area = ServerMain.INSTANCE.getAllEnclosures((ServerWorld) this.getWorld()).getArea(getBlockPos());
-            if (area != null && !area.areaOf(getBlockPos()).hasPerm(serverPlayer, Permission.CONTAINER)) {
-                serverPlayer.sendMessage(CONTAINER.getNoPermissionMsg(serverPlayer));
+            if (area != null && !area.areaOf(getBlockPos()).hasPerm(serverPlayer, permissions.CONTAINER)) {
+                serverPlayer.sendMessage(permissions.CONTAINER.getNoPermissionMsg(serverPlayer));
                 cir.setReturnValue(false);
             }
-            if (area != null && !area.areaOf(getBlockPos()).hasPerm(serverPlayer, Permission.VEHICLE)) {
-                serverPlayer.sendMessage(VEHICLE.getNoPermissionMsg(serverPlayer));
+            if (area != null && !area.areaOf(getBlockPos()).hasPerm(serverPlayer, permissions.VEHICLE)) {
+                serverPlayer.sendMessage(permissions.VEHICLE.getNoPermissionMsg(serverPlayer));
                 cir.setReturnValue(false);
             }
         }
@@ -43,12 +41,12 @@ public class MixinChestBoatEntity extends BoatEntity {
 
     @Inject(method = "interact", at = @At("HEAD"), cancellable = true)
     private void onInteract(PlayerEntity player, Hand hand, CallbackInfoReturnable<ActionResult> cir) {
-        if (!ServerMain.INSTANCE.checkPermission(getWorld(), getBlockPos(), player, VEHICLE)) {
-            player.sendMessage(VEHICLE.getNoPermissionMsg(player));
+        if (!ServerMain.INSTANCE.checkPermission(getWorld(), getBlockPos(), player, permissions.VEHICLE)) {
+            player.sendMessage(permissions.VEHICLE.getNoPermissionMsg(player));
             cir.setReturnValue(ActionResult.FAIL);
         }
-        if (!ServerMain.INSTANCE.checkPermission(getWorld(), getBlockPos(), player, CONTAINER)) {
-            player.sendMessage(CONTAINER.getNoPermissionMsg(player));
+        if (!ServerMain.INSTANCE.checkPermission(getWorld(), getBlockPos(), player, permissions.CONTAINER)) {
+            player.sendMessage(permissions.CONTAINER.getNoPermissionMsg(player));
             cir.setReturnValue(ActionResult.FAIL);
         }
     }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinChorusFruitItem.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinChorusFruitItem.java
@@ -15,7 +15,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
-import static com.github.zly2006.enclosure.utils.Permission.TELEPORT;
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
 
 @Mixin(ChorusFruitItem.class)
 public class MixinChorusFruitItem {
@@ -23,8 +23,8 @@ public class MixinChorusFruitItem {
     private void tp(ItemStack stack, World world, LivingEntity user, CallbackInfoReturnable<ItemStack> cir, ItemStack itemStack, double d, double e, double f, int i, double g, double h, double j, Vec3d vec3d) {
         if (user instanceof ServerPlayerEntity player) {
             BlockPos pos = Utils.toBlockPos(g, h, j);
-            if (!ServerMain.INSTANCE.checkPermission(player, TELEPORT, pos)) {
-                player.sendMessage(TELEPORT.getNoPermissionMsg(player));
+            if (!ServerMain.INSTANCE.checkPermission(player, permissions.TELEPORT, pos)) {
+                player.sendMessage(permissions.TELEPORT.getNoPermissionMsg(player));
                 cir.setReturnValue(stack);
             }
         }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinCreeperEntity.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinCreeperEntity.java
@@ -2,7 +2,6 @@ package com.github.zly2006.enclosure.mixin;
 
 import com.github.zly2006.enclosure.EnclosureArea;
 import com.github.zly2006.enclosure.ServerMain;
-import com.github.zly2006.enclosure.utils.Permission;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.mob.CreeperEntity;
 import net.minecraft.entity.mob.HostileEntity;
@@ -17,6 +16,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
+
 @Mixin(CreeperEntity.class)
 public class MixinCreeperEntity extends HostileEntity {
     protected MixinCreeperEntity(EntityType<? extends HostileEntity> entityType, World world) {
@@ -26,8 +27,8 @@ public class MixinCreeperEntity extends HostileEntity {
     @Inject(method = "interactMob", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/mob/CreeperEntity;ignite()V"), cancellable = true)
     private void onUse(PlayerEntity player, Hand hand, CallbackInfoReturnable<ActionResult> cir) {
         EnclosureArea area = ServerMain.INSTANCE.getSmallestEnclosure((ServerWorld) getWorld(), getBlockPos());
-        if (area != null && !area.hasPerm((ServerPlayerEntity) player, Permission.PRIME_TNT)) {
-            player.sendMessage(Permission.PRIME_TNT.getNoPermissionMsg(player));
+        if (area != null && !area.hasPerm((ServerPlayerEntity) player, permissions.PRIME_TNT)) {
+            player.sendMessage(permissions.PRIME_TNT.getNoPermissionMsg(player));
             cir.setReturnValue(ActionResult.FAIL);
         }
     }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinCrossBowItem.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinCrossBowItem.java
@@ -14,15 +14,15 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
-import static com.github.zly2006.enclosure.utils.Permission.SHOOT;
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
 
 @Mixin(CrossbowItem.class)
 public class MixinCrossBowItem {
-    @Inject(method = "use", locals = LocalCapture.CAPTURE_FAILSOFT, at = @At(value = "INVOKE",target = "Lnet/minecraft/item/CrossbowItem;shootAll(Lnet/minecraft/world/World;Lnet/minecraft/entity/LivingEntity;Lnet/minecraft/util/Hand;Lnet/minecraft/item/ItemStack;FF)V"), cancellable = true)
+    @Inject(method = "use", locals = LocalCapture.CAPTURE_FAILSOFT, at = @At(value = "INVOKE", target = "Lnet/minecraft/item/CrossbowItem;shootAll(Lnet/minecraft/world/World;Lnet/minecraft/entity/LivingEntity;Lnet/minecraft/util/Hand;Lnet/minecraft/item/ItemStack;FF)V"), cancellable = true)
     private void onShoot(World world, PlayerEntity user, Hand hand, CallbackInfoReturnable<TypedActionResult<ItemStack>> cir, ItemStack itemStack) {
         if (user instanceof ServerPlayerEntity player) {
-            if (!ServerMain.INSTANCE.checkPermission(player, SHOOT, player.getBlockPos())) {
-                player.sendMessage(SHOOT.getNoPermissionMsg(player));
+            if (!ServerMain.INSTANCE.checkPermission(player, permissions.SHOOT, player.getBlockPos())) {
+                player.sendMessage(permissions.SHOOT.getNoPermissionMsg(player));
                 player.currentScreenHandler.syncState();  // update player's inventory
                 cir.setReturnValue(TypedActionResult.fail(itemStack));
             }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinDispenserBlock.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinDispenserBlock.java
@@ -2,7 +2,6 @@ package com.github.zly2006.enclosure.mixin;
 
 import com.github.zly2006.enclosure.EnclosureArea;
 import com.github.zly2006.enclosure.ServerMain;
-import com.github.zly2006.enclosure.utils.Permission;
 import net.minecraft.block.DispenserBlock;
 import net.minecraft.block.dispenser.DispenserBehavior;
 import net.minecraft.block.dispenser.ItemDispenserBehavior;
@@ -18,6 +17,8 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
+
 @Mixin(DispenserBlock.class)
 public class MixinDispenserBlock {
     @Inject(method = "dispense", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/dispenser/DispenserBehavior;dispense(Lnet/minecraft/util/math/BlockPointer;Lnet/minecraft/item/ItemStack;)Lnet/minecraft/item/ItemStack;"), locals = LocalCapture.CAPTURE_FAILHARD, cancellable = true)
@@ -26,7 +27,7 @@ public class MixinDispenserBlock {
         EnclosureArea area = ServerMain.INSTANCE.getSmallestEnclosure(world, pos);
         EnclosureArea area2 = ServerMain.INSTANCE.getSmallestEnclosure(world, pos.offset(facing));
         if (area2 != area && area2 != null &&
-                !area2.hasPubPerm(Permission.DISPENSER)) {
+                !area2.hasPubPerm(permissions.DISPENSER)) {
             if (dispenserBehavior.getClass() != ItemDispenserBehavior.class) {
                 ci.cancel(); // we only allow default ItemDispenserBehavior
             }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinEndCrystalEntity.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinEndCrystalEntity.java
@@ -1,6 +1,5 @@
 package com.github.zly2006.enclosure.mixin;
 
-import com.github.zly2006.enclosure.utils.Permission;
 import com.github.zly2006.enclosure.utils.Utils;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
@@ -12,6 +11,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
+
 @Mixin(EndCrystalEntity.class)
 public abstract class MixinEndCrystalEntity extends Entity {
     public MixinEndCrystalEntity(EntityType<?> type, World world) {
@@ -20,7 +21,7 @@ public abstract class MixinEndCrystalEntity extends Entity {
 
     @Inject(method = "damage", at = @At("HEAD"), cancellable = true)
     private void onDamage(DamageSource source, float amount, CallbackInfoReturnable<Boolean> cir) {
-        if (!Utils.commonOnDamage(source, getBlockPos(), getWorld(), Permission.BREAK_BLOCK)) {
+        if (!Utils.commonOnDamage(source, getBlockPos(), getWorld(), permissions.BREAK_BLOCK)) {
             cir.setReturnValue(false);
         }
     }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinEnderDragonEntity.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinEnderDragonEntity.java
@@ -3,7 +3,6 @@ package com.github.zly2006.enclosure.mixin;
 import com.github.zly2006.enclosure.EnclosureArea;
 import com.github.zly2006.enclosure.EnclosureList;
 import com.github.zly2006.enclosure.ServerMain;
-import com.github.zly2006.enclosure.utils.Permission;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.boss.dragon.EnderDragonEntity;
 import net.minecraft.entity.mob.MobEntity;
@@ -13,6 +12,8 @@ import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
+
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
 
 @Mixin(EnderDragonEntity.class)
 public class MixinEnderDragonEntity extends MobEntity {
@@ -27,7 +28,7 @@ public class MixinEnderDragonEntity extends MobEntity {
         }
         EnclosureList list = ServerMain.INSTANCE.getAllEnclosures((ServerWorld) getWorld());
         EnclosureArea a = list.getArea(pos);
-        if (a != null && !a.areaOf(pos).hasPubPerm(Permission.DRAGON_DESTROY)) {
+        if (a != null && !a.areaOf(pos).hasPubPerm(permissions.DRAGON_DESTROY)) {
             return true;
         }
         return this.getWorld().removeBlock(pos, false);

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinEnderPearl.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinEnderPearl.java
@@ -2,7 +2,6 @@ package com.github.zly2006.enclosure.mixin;
 
 import com.github.zly2006.enclosure.EnclosureArea;
 import com.github.zly2006.enclosure.ServerMain;
-import com.github.zly2006.enclosure.utils.Permission;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.projectile.thrown.EnderPearlEntity;
 import net.minecraft.entity.projectile.thrown.ThrownItemEntity;
@@ -14,6 +13,8 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
 
 @Mixin(EnderPearlEntity.class)
 public abstract class MixinEnderPearl extends ThrownItemEntity {
@@ -27,8 +28,8 @@ public abstract class MixinEnderPearl extends ThrownItemEntity {
             EnclosureArea area = ServerMain.INSTANCE.getSmallestEnclosure(serverWorld, getBlockPos());
             if (area == null)
                 return;
-            if (!area.hasPerm(player, Permission.TELEPORT)) {
-                player.sendMessage(Permission.TELEPORT.getNoPermissionMsg(player));
+            if (!area.hasPerm(player, permissions.TELEPORT)) {
+                player.sendMessage(permissions.TELEPORT.getNoPermissionMsg(player));
                 ci.cancel();
                 discard();
             }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinExplosion.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinExplosion.java
@@ -3,7 +3,6 @@ package com.github.zly2006.enclosure.mixin;
 import com.github.zly2006.enclosure.EnclosureArea;
 import com.github.zly2006.enclosure.EnclosureList;
 import com.github.zly2006.enclosure.ServerMain;
-import com.github.zly2006.enclosure.utils.Permission;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.minecraft.entity.Entity;
 import net.minecraft.server.world.ServerWorld;
@@ -17,6 +16,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
 import java.util.List;
+
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
 
 @Mixin(Explosion.class)
 public abstract class MixinExplosion {
@@ -36,11 +37,11 @@ public abstract class MixinExplosion {
                 assert e != null;
                 BlockPos pos = e.getBlockPos();
                 EnclosureArea a = enclosureList.getArea(pos);
-                return a != null && !a.areaOf(pos).hasPubPerm(Permission.EXPLOSION);
+                return a != null && !a.areaOf(pos).hasPubPerm(permissions.EXPLOSION);
             });
             this.affectedBlocks.removeIf(pos -> {
                 EnclosureArea a = enclosureList.getArea(pos);
-                return a != null && !a.areaOf(pos).hasPubPerm(Permission.EXPLOSION);
+                return a != null && !a.areaOf(pos).hasPubPerm(permissions.EXPLOSION);
             });
         }
         return list;

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinFallingBlockEntity.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinFallingBlockEntity.java
@@ -2,8 +2,6 @@ package com.github.zly2006.enclosure.mixin;
 
 import com.github.zly2006.enclosure.EnclosureArea;
 import com.github.zly2006.enclosure.ServerMain;
-import com.github.zly2006.enclosure.utils.Permission;
-import net.fabricmc.api.Environment;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.FallingBlockEntity;
@@ -15,6 +13,8 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
 
 @Mixin(value = FallingBlockEntity.class)
 public abstract class MixinFallingBlockEntity extends Entity {
@@ -42,7 +42,7 @@ public abstract class MixinFallingBlockEntity extends Entity {
         if (currentArea == null || sourceArea == currentArea) {
             return;
         }
-        if (!currentArea.hasPubPerm(Permission.FALLING_BLOCK)) {
+        if (!currentArea.hasPubPerm(permissions.FALLING_BLOCK)) {
             discard();
             ci.cancel();
         }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinFarmlandBlock.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinFarmlandBlock.java
@@ -1,7 +1,6 @@
 package com.github.zly2006.enclosure.mixin;
 
 import com.github.zly2006.enclosure.ServerMain;
-import com.github.zly2006.enclosure.utils.Permission;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.FarmlandBlock;
 import net.minecraft.entity.Entity;
@@ -13,13 +12,15 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
+
 @Mixin(FarmlandBlock.class)
 public class MixinFarmlandBlock {
     @Inject(method = "onLandedUpon", at = @At("HEAD"), cancellable = true)
     private void onLandedUpon(World world, BlockState state, BlockPos pos, Entity entity, float fallDistance, CallbackInfo ci) {
         if (entity instanceof PlayerEntity player) {
-            if (!ServerMain.INSTANCE.checkPermission(world, pos, player, Permission.FARMLAND_DESTROY)) {
-                entity.sendMessage(Permission.FARMLAND_DESTROY.getNoPermissionMsg(player));
+            if (!ServerMain.INSTANCE.checkPermission(world, pos, player, permissions.FARMLAND_DESTROY)) {
+                entity.sendMessage(permissions.FARMLAND_DESTROY.getNoPermissionMsg(player));
                 ci.cancel();
             }
         }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinFireBlock.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinFireBlock.java
@@ -3,7 +3,6 @@ package com.github.zly2006.enclosure.mixin;
 import com.github.zly2006.enclosure.EnclosureArea;
 import com.github.zly2006.enclosure.EnclosureList;
 import com.github.zly2006.enclosure.ServerMain;
-import com.github.zly2006.enclosure.utils.Permission;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.FireBlock;
@@ -15,13 +14,15 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
+
 @Mixin(FireBlock.class)
 public class MixinFireBlock {
     private void set(World instance, BlockPos pos, BlockState blockState, int i) {
         if (instance.isClient) return;
         EnclosureList list = ServerMain.INSTANCE.getAllEnclosures((ServerWorld) instance);
         EnclosureArea area = list.getArea(pos);
-        if (area == null || area.areaOf(pos).hasPubPerm(Permission.FIRE_SPREADING)) {
+        if (area == null || area.areaOf(pos).hasPubPerm(permissions.FIRE_SPREADING)) {
             instance.setBlockState(pos, blockState, i);
         }
     }
@@ -30,7 +31,7 @@ public class MixinFireBlock {
         if (instance.isClient) return;
         EnclosureList list = ServerMain.INSTANCE.getAllEnclosures((ServerWorld) instance);
         EnclosureArea area = list.getArea(pos);
-        if (area != null && !area.areaOf(pos).hasPubPerm(Permission.FIRE_SPREADING)) {
+        if (area != null && !area.areaOf(pos).hasPubPerm(permissions.FIRE_SPREADING)) {
             if (instance.getBlockState(pos).isOf(Blocks.FIRE)) {
                 // 但是允许火熄灭
                 instance.removeBlock(pos, move);
@@ -68,7 +69,7 @@ public class MixinFireBlock {
     private void redirectSetter(World instance, BlockPos pos) {
         if (instance.isClient) return;
         EnclosureArea area = ServerMain.INSTANCE.getSmallestEnclosure((ServerWorld) instance, pos);
-        if (area == null || area.hasPubPerm(Permission.FIRE_SPREADING)) {
+        if (area == null || area.hasPubPerm(permissions.FIRE_SPREADING)) {
             TntBlock.primeTnt(instance, pos);
         }  // 不允许火点燃TNT
     }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinFlowableFluid.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinFlowableFluid.java
@@ -2,7 +2,6 @@ package com.github.zly2006.enclosure.mixin;
 
 import com.github.zly2006.enclosure.EnclosureArea;
 import com.github.zly2006.enclosure.ServerMain;
-import com.github.zly2006.enclosure.utils.Permission;
 import net.minecraft.block.BlockState;
 import net.minecraft.fluid.FlowableFluid;
 import net.minecraft.fluid.Fluid;
@@ -16,6 +15,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
+
 @Mixin(FlowableFluid.class)
 public abstract class MixinFlowableFluid {
     @Inject(method = "canFlow", at = @At("HEAD"), cancellable = true)
@@ -24,7 +25,7 @@ public abstract class MixinFlowableFluid {
             EnclosureArea from = ServerMain.INSTANCE.getSmallestEnclosure(serverWorld, fluidPos);
             EnclosureArea to = ServerMain.INSTANCE.getSmallestEnclosure(serverWorld, flowTo);
             if (to != null && to != from) {
-                if (!to.hasPubPerm(Permission.FLUID)) {
+                if (!to.hasPubPerm(permissions.FLUID)) {
                     cir.setReturnValue(false);
                 }
             }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinHopperBlockEntity.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinHopperBlockEntity.java
@@ -32,6 +32,7 @@ public class MixinHopperBlockEntity extends BlockEntity {
             cir.setReturnValue(false);
         }
     }
+
     @Inject(method = "extract(Lnet/minecraft/inventory/Inventory;Lnet/minecraft/entity/ItemEntity;)Z", at = @At("HEAD"), cancellable = true)
     private static void onExtract(Inventory inventory, ItemEntity itemEntity, CallbackInfoReturnable<Boolean> cir) {
         UUID owner = itemEntity.owner;

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinHopperMinecartEntity.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinHopperMinecartEntity.java
@@ -2,7 +2,6 @@ package com.github.zly2006.enclosure.mixin;
 
 import com.github.zly2006.enclosure.EnclosureArea;
 import com.github.zly2006.enclosure.ServerMain;
-import com.github.zly2006.enclosure.utils.Permission;
 import com.github.zly2006.enclosure.utils.RayCast;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.vehicle.AbstractMinecartEntity;
@@ -16,11 +15,14 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
+
 @Mixin(HopperMinecartEntity.class)
 public abstract class MixinHopperMinecartEntity extends AbstractMinecartEntity {
     Vec3d lastVelocity;
     Vec3d lastPosition;
     BlockPos lastBlockPos;
+
     public MixinHopperMinecartEntity(EntityType<?> type, World world) {
         super(type, world);
     }
@@ -39,13 +41,13 @@ public abstract class MixinHopperMinecartEntity extends AbstractMinecartEntity {
             EnclosureArea a2 = ServerMain.INSTANCE.getSmallestEnclosure(world, getBlockPos());
             if (a1 != a2) {
                 RayCast rayCast = new RayCast(lastPosition, getPos());
-                if (a1 != null && !a1.hasPubPerm(Permission.CONTAINER)) {
+                if (a1 != null && !a1.hasPubPerm(permissions.CONTAINER)) {
                     if (rayCast.intersect(a1.toBox()) != null) {
                         setVelocity(lastVelocity);
                         setPos(lastPosition.x, lastPosition.y, lastPosition.z);
                     }
                 }
-                if (a2 != null && !a2.hasPubPerm(Permission.CONTAINER)) {
+                if (a2 != null && !a2.hasPubPerm(permissions.CONTAINER)) {
                     if (rayCast.intersect(a2.toBox()) != null) {
                         setVelocity(lastVelocity);
                         setPos(lastPosition.x, lastPosition.y, lastPosition.z);

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinItemEntity.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinItemEntity.java
@@ -3,7 +3,6 @@ package com.github.zly2006.enclosure.mixin;
 import com.github.zly2006.enclosure.EnclosureArea;
 import com.github.zly2006.enclosure.ServerMain;
 import com.github.zly2006.enclosure.access.PlayerAccess;
-import com.github.zly2006.enclosure.utils.Permission;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.ItemEntity;
@@ -16,6 +15,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
+
 @Mixin(ItemEntity.class)
 public abstract class MixinItemEntity extends Entity {
     public MixinItemEntity(EntityType<?> type, World world) {
@@ -26,8 +27,8 @@ public abstract class MixinItemEntity extends Entity {
     private void onPlayerCollision(PlayerEntity player, CallbackInfo ci) {
         if (getWorld() instanceof ServerWorld serverWorld) {
             EnclosureArea area = ServerMain.INSTANCE.getAllEnclosures(serverWorld).getArea(getBlockPos());
-            if (area != null && !area.areaOf(getBlockPos()).hasPerm((ServerPlayerEntity) player, Permission.PICKUP_ITEM)) {
-                ((PlayerAccess) player).sendMessageWithCD(Permission.PICKUP_ITEM::getNoPermissionMsg);
+            if (area != null && !area.areaOf(getBlockPos()).hasPerm((ServerPlayerEntity) player, permissions.PICKUP_ITEM)) {
+                ((PlayerAccess) player).sendMessageWithCD(permissions.PICKUP_ITEM::getNoPermissionMsg);
                 ci.cancel();
             }
         }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinItemFrameEntity.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinItemFrameEntity.java
@@ -2,7 +2,6 @@ package com.github.zly2006.enclosure.mixin;
 
 import com.github.zly2006.enclosure.EnclosureArea;
 import com.github.zly2006.enclosure.ServerMain;
-import com.github.zly2006.enclosure.utils.Permission;
 import com.github.zly2006.enclosure.utils.Utils;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.damage.DamageSource;
@@ -19,6 +18,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
+
 @Mixin(ItemFrameEntity.class)
 public abstract class MixinItemFrameEntity extends AbstractDecorationEntity {
     protected MixinItemFrameEntity(EntityType<? extends AbstractDecorationEntity> entityType, World world) {
@@ -29,8 +30,8 @@ public abstract class MixinItemFrameEntity extends AbstractDecorationEntity {
     private void onUse(PlayerEntity player, Hand hand, CallbackInfoReturnable<ActionResult> cir) {
         if (player instanceof ServerPlayerEntity serverPlayer) {
             EnclosureArea area = ServerMain.INSTANCE.getSmallestEnclosure((ServerWorld) serverPlayer.getWorld(), getBlockPos());
-            if (area != null && !area.areaOf(getBlockPos()).hasPerm(serverPlayer, Permission.ITEM_FRAME)) {
-                player.sendMessage(Permission.ITEM_FRAME.getNoPermissionMsg(serverPlayer));
+            if (area != null && !area.areaOf(getBlockPos()).hasPerm(serverPlayer, permissions.ITEM_FRAME)) {
+                player.sendMessage(permissions.ITEM_FRAME.getNoPermissionMsg(serverPlayer));
                 cir.setReturnValue(ActionResult.FAIL);
             }
         }
@@ -38,7 +39,7 @@ public abstract class MixinItemFrameEntity extends AbstractDecorationEntity {
 
     @Inject(method = "damage", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/decoration/ItemFrameEntity;dropHeldStack(Lnet/minecraft/entity/Entity;Z)V"), cancellable = true)
     private void onDamages(DamageSource source, float amount, CallbackInfoReturnable<Boolean> cir) {
-        if (!Utils.commonOnDamage(source, getBlockPos(), getWorld(), Permission.ITEM_FRAME)) {
+        if (!Utils.commonOnDamage(source, getBlockPos(), getWorld(), permissions.ITEM_FRAME)) {
             cir.setReturnValue(false);
         }
     }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinLanguage.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinLanguage.java
@@ -18,7 +18,7 @@ public class MixinLanguage {
     private static void create(CallbackInfoReturnable<Language> cir, ImmutableMap.Builder builder, BiConsumer biConsumer) {
         if (ServerMain.INSTANCE.getCommonConfig().injectServerLanguage) {
             ServerMain.INSTANCE.getTranslation().entrySet().forEach(entry ->
-                builder.put(entry.getKey(), entry.getValue().getAsString()));
+                    builder.put(entry.getKey(), entry.getValue().getAsString()));
         }
     }
 }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinLeadItem.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinLeadItem.java
@@ -11,14 +11,14 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import static com.github.zly2006.enclosure.utils.Permission.LEASH;
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
 
 @Mixin(LeadItem.class)
 public class MixinLeadItem {
     @Inject(method = "attachHeldMobsToBlock", at = @At("HEAD"), cancellable = true)
     private static void onAttachHeldMobsToBlock(PlayerEntity player, World world, BlockPos pos, CallbackInfoReturnable<ActionResult> cir) {
-        if (!ServerMain.INSTANCE.checkPermission(world, pos, player, LEASH)) {
-            player.sendMessage(LEASH.getNoPermissionMsg(player));
+        if (!ServerMain.INSTANCE.checkPermission(world, pos, player, permissions.LEASH)) {
+            player.sendMessage(permissions.LEASH.getNoPermissionMsg(player));
             cir.setReturnValue(ActionResult.PASS);
         }
     }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinLecternScreenHandler.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinLecternScreenHandler.java
@@ -2,7 +2,6 @@ package com.github.zly2006.enclosure.mixin;
 
 import com.github.zly2006.enclosure.ServerMain;
 import com.github.zly2006.enclosure.access.LecternInventoryAccess;
-import com.github.zly2006.enclosure.utils.Permission;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.Inventory;
 import net.minecraft.screen.LecternScreenHandler;
@@ -17,9 +16,13 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
+
 @Mixin(LecternScreenHandler.class)
 public abstract class MixinLecternScreenHandler extends ScreenHandler {
-    @Shadow @Final private Inventory inventory;
+    @Shadow
+    @Final
+    private Inventory inventory;
 
     protected MixinLecternScreenHandler(@Nullable ScreenHandlerType<?> type, int syncId) {
         super(type, syncId);
@@ -28,11 +31,11 @@ public abstract class MixinLecternScreenHandler extends ScreenHandler {
     @Inject(method = "onButtonClick", at = @At("HEAD"), cancellable = true)
     private void onButtonClick(PlayerEntity player, int id, CallbackInfoReturnable<Boolean> cir) {
         if (player instanceof ServerPlayerEntity serverPlayer && inventory instanceof LecternInventoryAccess access) {
-            if (!ServerMain.INSTANCE.checkPermission(serverPlayer, Permission.TAKE_BOOK, access.getPos())) {
+            if (!ServerMain.INSTANCE.checkPermission(serverPlayer, permissions.TAKE_BOOK, access.getPos())) {
                 if (id == 3) {
                     cir.setReturnValue(false);
                     serverPlayer.closeHandledScreen();
-                    serverPlayer.sendMessage(Permission.TAKE_BOOK.getNoPermissionMsg(serverPlayer));
+                    serverPlayer.sendMessage(permissions.TAKE_BOOK.getNoPermissionMsg(serverPlayer));
                 }
             }
         }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinLeveledCauldronBlock.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinLeveledCauldronBlock.java
@@ -3,7 +3,6 @@ package com.github.zly2006.enclosure.mixin;
 import com.github.zly2006.enclosure.EnclosureArea;
 import com.github.zly2006.enclosure.EnclosureList;
 import com.github.zly2006.enclosure.ServerMain;
-import com.github.zly2006.enclosure.utils.Permission;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.LeveledCauldronBlock;
 import net.minecraft.server.world.ServerWorld;
@@ -14,14 +13,16 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
+
 @Mixin(LeveledCauldronBlock.class)
 public class MixinLeveledCauldronBlock {
     @Inject(method = "onFireCollision", at = @At("HEAD"), cancellable = true)
-    private void onFireCollision(BlockState state, World world, BlockPos pos, CallbackInfo ci){
+    private void onFireCollision(BlockState state, World world, BlockPos pos, CallbackInfo ci) {
         if (!world.isClient) {
             EnclosureList list = ServerMain.INSTANCE.getAllEnclosures((ServerWorld) world);
             EnclosureArea area = list.getArea(pos);
-            if (area != null && !area.areaOf(pos).hasPubPerm(Permission.CONSUMPTIVELY_EXTINGUISH)) {
+            if (area != null && !area.areaOf(pos).hasPubPerm(permissions.CONSUMPTIVELY_EXTINGUISH)) {
                 ci.cancel();
             }
         }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinLivingEntity.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinLivingEntity.java
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import static com.github.zly2006.enclosure.utils.Permission.*;
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
 
 @Mixin(LivingEntity.class)
 public abstract class MixinLivingEntity extends Entity {
@@ -25,22 +25,19 @@ public abstract class MixinLivingEntity extends Entity {
             return;
         }
         if (Utils.isAnimal(this)) {
-            if (!Utils.commonOnPlayerDamage(source, getBlockPos(), getWorld(), ATTACK_ANIMAL)) {
+            if (!Utils.commonOnPlayerDamage(source, getBlockPos(), getWorld(), permissions.ATTACK_ANIMAL)) {
                 cir.setReturnValue(false);
             }
-        }
-        else if (Utils.isMonster(this)) {
-            if (!Utils.commonOnPlayerDamage(source, getBlockPos(), getWorld(), ATTACK_MONSTER)) {
+        } else if (Utils.isMonster(this)) {
+            if (!Utils.commonOnPlayerDamage(source, getBlockPos(), getWorld(), permissions.ATTACK_MONSTER)) {
                 cir.setReturnValue(false);
             }
-        }
-        else if (getType() == EntityType.VILLAGER) {
-            if (!Utils.commonOnPlayerDamage(source, getBlockPos(), getWorld(), ATTACK_VILLAGER)) {
+        } else if (getType() == EntityType.VILLAGER) {
+            if (!Utils.commonOnPlayerDamage(source, getBlockPos(), getWorld(), permissions.ATTACK_VILLAGER)) {
                 cir.setReturnValue(false);
             }
-        }
-        else {
-            if (!Utils.commonOnPlayerDamage(source, getBlockPos(), getWorld(), ATTACK_ENTITY)) {
+        } else {
+            if (!Utils.commonOnPlayerDamage(source, getBlockPos(), getWorld(), permissions.ATTACK_ENTITY)) {
                 cir.setReturnValue(false);
             }
         }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinLockableContainerBlockEntity.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinLockableContainerBlockEntity.java
@@ -16,7 +16,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import static com.github.zly2006.enclosure.utils.Permission.CONTAINER;
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
 
 @Mixin(LockableContainerBlockEntity.class)
 public class MixinLockableContainerBlockEntity extends BlockEntity {
@@ -31,8 +31,8 @@ public class MixinLockableContainerBlockEntity extends BlockEntity {
                 return;
             }
             EnclosureArea area = ServerMain.INSTANCE.getSmallestEnclosure((ServerWorld) player.getWorld(), getPos());
-            if (area != null && !area.hasPerm(player, CONTAINER)) {
-                player.sendMessage(CONTAINER.getNoPermissionMsg(player));
+            if (area != null && !area.hasPerm(player, permissions.CONTAINER)) {
+                player.sendMessage(permissions.CONTAINER.getNoPermissionMsg(player));
                 cir.setReturnValue(false);
             }
         }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinMinecartEntity.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinMinecartEntity.java
@@ -13,7 +13,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import static com.github.zly2006.enclosure.utils.Permission.VEHICLE;
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
 
 @Mixin(MinecartEntity.class)
 public abstract class MixinMinecartEntity extends AbstractMinecartEntity {
@@ -23,8 +23,8 @@ public abstract class MixinMinecartEntity extends AbstractMinecartEntity {
 
     @Inject(method = "interact", at = @At("HEAD"), cancellable = true)
     private void onInteract(PlayerEntity player, Hand hand, CallbackInfoReturnable<ActionResult> cir) {
-        if (!ServerMain.INSTANCE.checkPermission(getWorld(), getBlockPos(), player, VEHICLE)) {
-            player.sendMessage(VEHICLE.getNoPermissionMsg(player));
+        if (!ServerMain.INSTANCE.checkPermission(getWorld(), getBlockPos(), player, permissions.VEHICLE)) {
+            player.sendMessage(permissions.VEHICLE.getNoPermissionMsg(player));
             cir.setReturnValue(ActionResult.FAIL);
         }
     }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinMobEntity.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinMobEntity.java
@@ -1,7 +1,6 @@
 package com.github.zly2006.enclosure.mixin;
 
 import com.github.zly2006.enclosure.ServerMain;
-import com.github.zly2006.enclosure.utils.Permission;
 import net.minecraft.entity.Bucketable;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
@@ -18,6 +17,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
+
 @Mixin(MobEntity.class)
 public abstract class MixinMobEntity extends LivingEntity {
     protected MixinMobEntity(EntityType<? extends LivingEntity> entityType, World world) {
@@ -27,10 +28,10 @@ public abstract class MixinMobEntity extends LivingEntity {
     @Inject(method = "interact", at = @At("HEAD"), cancellable = true)
     private void interact(PlayerEntity player, Hand hand, CallbackInfoReturnable<ActionResult> cir) {
         if (this instanceof Bucketable && player.getStackInHand(hand).isOf(Items.WATER_BUCKET)) {
-            if (!ServerMain.INSTANCE.checkPermission(getWorld(), getBlockPos(), player, Permission.FISH)) {
+            if (!ServerMain.INSTANCE.checkPermission(getWorld(), getBlockPos(), player, permissions.FISH)) {
                 ServerPlayerEntity serverPlayer = (ServerPlayerEntity) player;
                 serverPlayer.networkHandler.sendPacket(createSpawnPacket());
-                serverPlayer.sendMessage(Permission.FISH.getNoPermissionMsg(player));
+                serverPlayer.sendMessage(permissions.FISH.getNoPermissionMsg(player));
                 serverPlayer.currentScreenHandler.syncState();
                 cir.setReturnValue(ActionResult.FAIL);
             }
@@ -39,10 +40,10 @@ public abstract class MixinMobEntity extends LivingEntity {
 
     @Inject(method = "canBeLeashedBy", at = @At("HEAD"), cancellable = true)
     private void canBeLeashedBy(PlayerEntity player, CallbackInfoReturnable<Boolean> cir) {
-        if (!ServerMain.INSTANCE.checkPermission(getWorld(), getBlockPos(), player, Permission.LEASH)) {
+        if (!ServerMain.INSTANCE.checkPermission(getWorld(), getBlockPos(), player, permissions.LEASH)) {
             ServerPlayerEntity serverPlayer = (ServerPlayerEntity) player;
             serverPlayer.networkHandler.sendPacket(new EntityAttachS2CPacket(this, null));
-            serverPlayer.sendMessage(Permission.LEASH.getNoPermissionMsg(player));
+            serverPlayer.sendMessage(permissions.LEASH.getNoPermissionMsg(player));
             serverPlayer.currentScreenHandler.syncState();
             cir.setReturnValue(false);
         }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinParrotEntity.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinParrotEntity.java
@@ -19,7 +19,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import static com.github.zly2006.enclosure.utils.Permission.PARROT_COOKIE;
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
 
 @Mixin(ParrotEntity.class)
 public abstract class MixinParrotEntity extends AnimalEntity {
@@ -37,8 +37,8 @@ public abstract class MixinParrotEntity extends AnimalEntity {
             if (player.getStackInHand(hand).isOf(COOKIE)) {
                 EnclosureArea area = ServerMain.INSTANCE.getAllEnclosures((ServerWorld) getWorld()).getArea(getBlockPos());
 
-                if (area != null && !area.areaOf(getBlockPos()).hasPerm(player, PARROT_COOKIE)) {
-                    player.sendMessage(PARROT_COOKIE.getNoPermissionMsg(player));
+                if (area != null && !area.areaOf(getBlockPos()).hasPerm(player, permissions.PARROT_COOKIE)) {
+                    player.sendMessage(permissions.PARROT_COOKIE.getNoPermissionMsg(player));
                     cir.setReturnValue(ActionResult.FAIL);
                 }
             }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinPistonBlock.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinPistonBlock.java
@@ -2,7 +2,6 @@ package com.github.zly2006.enclosure.mixin;
 
 import com.github.zly2006.enclosure.ServerMain;
 import com.github.zly2006.enclosure.mixinadatper.MixinPistonBlockKt;
-import com.github.zly2006.enclosure.utils.Permission;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.FacingBlock;
 import net.minecraft.block.PistonBlock;
@@ -17,6 +16,8 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
 
 @Mixin(PistonBlock.class)
 public class MixinPistonBlock extends FacingBlock {
@@ -44,7 +45,7 @@ public class MixinPistonBlock extends FacingBlock {
     @Redirect(method = "onSyncedBlockEvent", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;removeBlock(Lnet/minecraft/util/math/BlockPos;Z)Z"))
     private boolean protectBlockEvent(World world, BlockPos pos, boolean move) {
         if (world instanceof ServerWorld serverWorld && !serverWorld.getBlockState(pos).isOf(Blocks.PISTON_HEAD)) {
-            if (!ServerMain.INSTANCE.checkPermission(serverWorld, pos, null, Permission.BREAK_BLOCK)) {
+            if (!ServerMain.INSTANCE.checkPermission(serverWorld, pos, null, permissions.BREAK_BLOCK)) {
                 serverWorld.getChunkManager().markForUpdate(pos);
                 return false;
             }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinPlayerEntity.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinPlayerEntity.java
@@ -22,11 +22,13 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import static com.github.zly2006.enclosure.utils.Permission.PLACE_BLOCK;
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
 
 @Mixin(PlayerEntity.class)
 public abstract class MixinPlayerEntity extends LivingEntity {
-    @Shadow @Final private PlayerInventory inventory;
+    @Shadow
+    @Final
+    private PlayerInventory inventory;
 
     public MixinPlayerEntity(EntityType<? extends LivingEntity> type, World world) {
         super(type, world);
@@ -45,8 +47,8 @@ public abstract class MixinPlayerEntity extends LivingEntity {
     @Inject(method = "canPlaceOn", at = @At("HEAD"), cancellable = true)
     private void protectPlacing(BlockPos pos, Direction facing, ItemStack stack, CallbackInfoReturnable<Boolean> cir) {
         if (((LivingEntity) this) instanceof ServerPlayerEntity serverPlayer) {
-            if (!ServerMain.INSTANCE.checkPermission(serverPlayer, PLACE_BLOCK, pos)) {
-                serverPlayer.sendMessage(PLACE_BLOCK.getNoPermissionMsg(serverPlayer));
+            if (!ServerMain.INSTANCE.checkPermission(serverPlayer, permissions.PLACE_BLOCK, pos)) {
+                serverPlayer.sendMessage(permissions.PLACE_BLOCK.getNoPermissionMsg(serverPlayer));
                 cir.setReturnValue(false);
             }
         }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinPotionEntity.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinPotionEntity.java
@@ -3,7 +3,6 @@ package com.github.zly2006.enclosure.mixin;
 import com.github.zly2006.enclosure.EnclosureArea;
 import com.github.zly2006.enclosure.EnclosureList;
 import com.github.zly2006.enclosure.ServerMain;
-import com.github.zly2006.enclosure.utils.Permission;
 import net.minecraft.block.Block;
 import net.minecraft.block.CampfireBlock;
 import net.minecraft.entity.EntityType;
@@ -18,7 +17,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import static com.github.zly2006.enclosure.utils.Permission.USE_CAMPFIRE;
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
 import static net.minecraft.block.CampfireBlock.LIT;
 import static net.minecraft.block.CampfireBlock.WATERLOGGED;
 
@@ -37,9 +36,9 @@ public abstract class MixinPotionEntity extends ThrownItemEntity {
         if (block instanceof CampfireBlock) {
             EnclosureList list = ServerMain.INSTANCE.getAllEnclosures((ServerWorld) getWorld());
             EnclosureArea area = list.getArea(pos);
-            if (area != null && !area.areaOf(pos).hasPubPerm(Permission.USE_CAMPFIRE)) {
+            if (area != null && !area.areaOf(pos).hasPubPerm(permissions.USE_CAMPFIRE)) {
                 if (getOwner() instanceof ServerPlayerEntity player) {
-                    player.sendMessage(USE_CAMPFIRE.getNoPermissionMsg(player));
+                    player.sendMessage(permissions.USE_CAMPFIRE.getNoPermissionMsg(player));
                 }
                 getWorld().setBlockState(pos, getWorld().getBlockState(pos).with(WATERLOGGED, false).with(LIT, true), 252);
                 ci.cancel();

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinPowderSnowBlock.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinPowderSnowBlock.java
@@ -3,7 +3,6 @@ package com.github.zly2006.enclosure.mixin;
 import com.github.zly2006.enclosure.EnclosureArea;
 import com.github.zly2006.enclosure.EnclosureList;
 import com.github.zly2006.enclosure.ServerMain;
-import com.github.zly2006.enclosure.utils.Permission;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.PowderSnowBlock;
 import net.minecraft.entity.Entity;
@@ -15,6 +14,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
+
 @Mixin(PowderSnowBlock.class)
 public class MixinPowderSnowBlock {
     @Inject(method = "onEntityCollision", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;breakBlock(Lnet/minecraft/util/math/BlockPos;Z)Z"), cancellable = true)
@@ -24,7 +25,7 @@ public class MixinPowderSnowBlock {
         }
         EnclosureList list = ServerMain.INSTANCE.getAllEnclosures((ServerWorld) world);
         EnclosureArea area = list.getArea(pos);
-        if (area != null && !area.areaOf(pos).hasPubPerm(Permission.CONSUMPTIVELY_EXTINGUISH)) {
+        if (area != null && !area.areaOf(pos).hasPubPerm(permissions.CONSUMPTIVELY_EXTINGUISH)) {
             ci.cancel();
         }
     }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinRaidManager.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinRaidManager.java
@@ -16,6 +16,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(RaidManager.class)
 public class MixinRaidManager {
     private final static Logger LOGGER = LoggerFactory.getLogger("Enclosure Raid Alert");
+
     @Inject(method = "startRaid", at = @At("RETURN"))
     private void onStart(ServerPlayerEntity player, CallbackInfoReturnable<Raid> cir) {
         Raid raid = cir.getReturnValue();

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinSculkCatalystBlock.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinSculkCatalystBlock.java
@@ -3,7 +3,6 @@ package com.github.zly2006.enclosure.mixin;
 import com.github.zly2006.enclosure.EnclosureArea;
 import com.github.zly2006.enclosure.EnclosureList;
 import com.github.zly2006.enclosure.ServerMain;
-import com.github.zly2006.enclosure.utils.Permission;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.SculkCatalystBlock;
 import net.minecraft.server.world.ServerWorld;
@@ -14,13 +13,15 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
+
 @Mixin(SculkCatalystBlock.class)
 public class MixinSculkCatalystBlock {
     @Inject(method = "scheduledTick", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ServerWorld;setBlockState(Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/BlockState;I)Z"), cancellable = true)
     private void setBlock(BlockState state, ServerWorld world, BlockPos pos, Random random, CallbackInfo ci) {
         EnclosureList list = ServerMain.INSTANCE.getAllEnclosures(world);
         EnclosureArea area = list.getArea(pos);
-        if (area != null && !area.areaOf(pos).hasPubPerm(Permission.SCULK_SPREAD)) {
+        if (area != null && !area.areaOf(pos).hasPubPerm(permissions.SCULK_SPREAD)) {
             ci.cancel();
         }
     }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinSculkCatalystBlockEntity.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinSculkCatalystBlockEntity.java
@@ -2,7 +2,6 @@ package com.github.zly2006.enclosure.mixin;
 
 import com.github.zly2006.enclosure.EnclosureArea;
 import com.github.zly2006.enclosure.ServerMain;
-import com.github.zly2006.enclosure.utils.Permission;
 import net.minecraft.block.entity.SculkCatalystBlockEntity;
 import net.minecraft.block.entity.SculkSpreadManager;
 import net.minecraft.entity.LivingEntity;
@@ -20,11 +19,17 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
-@Mixin(SculkCatalystBlockEntity.Listener.class)
-public class MixinSculkCatalystBlockEntity  {
-    @Shadow @Final SculkSpreadManager spreadManager;
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
 
-    @Shadow @Final private PositionSource positionSource;
+@Mixin(SculkCatalystBlockEntity.Listener.class)
+public class MixinSculkCatalystBlockEntity {
+    @Shadow
+    @Final
+    SculkSpreadManager spreadManager;
+
+    @Shadow
+    @Final
+    private PositionSource positionSource;
 
     @Inject(method = "listen", locals = LocalCapture.CAPTURE_FAILSOFT, at = @At(value = "INVOKE", target = "Lnet/minecraft/block/entity/SculkSpreadManager;spread(Lnet/minecraft/util/math/BlockPos;I)V"), cancellable = true)
     private void spread(ServerWorld world, GameEvent event, GameEvent.Emitter emitter, Vec3d emitterPos, CallbackInfoReturnable<Boolean> cir, LivingEntity livingEntity, int i) {
@@ -33,7 +38,7 @@ public class MixinSculkCatalystBlockEntity  {
         }
         BlockPos blockPos = BlockPos.ofFloored(emitterPos.offset(Direction.UP, 0.5));
         EnclosureArea area = ServerMain.INSTANCE.getSmallestEnclosure((ServerWorld) livingEntity.getWorld(), blockPos);
-        if (area != null && !area.areaOf(blockPos).hasPubPerm(Permission.SCULK_SPREAD)) {
+        if (area != null && !area.areaOf(blockPos).hasPubPerm(permissions.SCULK_SPREAD)) {
             cir.setReturnValue(false);
         }
     }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinSculkSpreadManagerCursor.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinSculkSpreadManagerCursor.java
@@ -3,8 +3,6 @@ package com.github.zly2006.enclosure.mixin;
 import com.github.zly2006.enclosure.EnclosureArea;
 import com.github.zly2006.enclosure.EnclosureList;
 import com.github.zly2006.enclosure.ServerMain;
-import com.github.zly2006.enclosure.utils.Permission;
-import net.fabricmc.api.Environment;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.SculkSpreadable;
 import net.minecraft.block.entity.SculkSpreadManager;
@@ -20,6 +18,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.Collection;
 
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
+
 @Mixin(SculkSpreadManager.Cursor.class)
 public class MixinSculkSpreadManagerCursor {
     @Inject(method = "canSpread(Lnet/minecraft/world/WorldAccess;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/util/math/BlockPos;)Z", at = @At("HEAD"), cancellable = true)
@@ -30,7 +30,7 @@ public class MixinSculkSpreadManagerCursor {
             }
             EnclosureList list = ServerMain.INSTANCE.getAllEnclosures(serverWorld);
             EnclosureArea area = list.getArea(targetPos);
-            if (area != null && !area.areaOf(targetPos).hasPubPerm(Permission.SCULK_SPREAD)) {
+            if (area != null && !area.areaOf(targetPos).hasPubPerm(permissions.SCULK_SPREAD)) {
                 cir.setReturnValue(false);
             }
         }
@@ -41,7 +41,7 @@ public class MixinSculkSpreadManagerCursor {
         if (world instanceof ServerWorld serverWorld) {
             EnclosureList list = ServerMain.INSTANCE.getAllEnclosures(serverWorld);
             EnclosureArea area = list.getArea(pos);
-            if (area != null && !area.areaOf(pos).hasPubPerm(Permission.SCULK_SPREAD)) {
+            if (area != null && !area.areaOf(pos).hasPubPerm(permissions.SCULK_SPREAD)) {
                 return false;
             }
         }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinSculkVeinBlock.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinSculkVeinBlock.java
@@ -3,7 +3,6 @@ package com.github.zly2006.enclosure.mixin;
 import com.github.zly2006.enclosure.EnclosureArea;
 import com.github.zly2006.enclosure.EnclosureList;
 import com.github.zly2006.enclosure.ServerMain;
-import com.github.zly2006.enclosure.utils.Permission;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.SculkVeinBlock;
 import net.minecraft.block.entity.SculkSpreadManager;
@@ -20,28 +19,33 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.Collection;
 
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
+
 @Mixin(SculkVeinBlock.class)
 public class MixinSculkVeinBlock {
     private static boolean disallow(WorldAccess world, BlockPos pos) {
         if (world instanceof ServerWorld serverWorld) {
             EnclosureList list = ServerMain.INSTANCE.getAllEnclosures(serverWorld);
             EnclosureArea area = list.getArea(pos);
-            return area != null && !area.areaOf(pos).hasPubPerm(Permission.SCULK_SPREAD);
+            return area != null && !area.areaOf(pos).hasPubPerm(permissions.SCULK_SPREAD);
         }
         return false;
     }
+
     @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/world/WorldAccess;setBlockState(Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/BlockState;I)Z"), method = "place", cancellable = true)
     private static void place(WorldAccess world, BlockPos pos, BlockState state, Collection<Direction> directions, CallbackInfoReturnable<Boolean> cir) {
         if (disallow(world, pos)) {
             cir.setReturnValue(false);
         }
     }
+
     @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/world/WorldAccess;setBlockState(Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/BlockState;I)Z"), method = "spreadAtSamePosition", cancellable = true)
     private void spreadAtSamePosition(WorldAccess world, BlockState state, BlockPos pos, Random random, CallbackInfo ci) {
         if (disallow(world, pos)) {
             ci.cancel();
         }
     }
+
     @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/world/WorldAccess;setBlockState(Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/BlockState;I)Z"), method = "convertToBlock", cancellable = true)
     private void convertToBlock(SculkSpreadManager spreadManager, WorldAccess world, BlockPos pos, Random random, CallbackInfoReturnable<Boolean> cir) {
         if (disallow(world, pos)) {

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinServerMetadata.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinServerMetadata.java
@@ -19,7 +19,9 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(ServerMetadata.class)
 public abstract class MixinServerMetadata implements ServerMetadataAccess {
     @Mutable
-    @Shadow @Final public static Codec<ServerMetadata> CODEC;
+    @Shadow
+    @Final
+    public static Codec<ServerMetadata> CODEC;
 
     private String modName = ServerMainKt.MOD_ID;
     private Version modVersion = ServerMainKt.MOD_VERSION;

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinStorageMinecartEntity.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinStorageMinecartEntity.java
@@ -2,7 +2,6 @@ package com.github.zly2006.enclosure.mixin;
 
 import com.github.zly2006.enclosure.EnclosureArea;
 import com.github.zly2006.enclosure.ServerMain;
-import com.github.zly2006.enclosure.utils.Permission;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.vehicle.AbstractMinecartEntity;
@@ -15,7 +14,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import static com.github.zly2006.enclosure.utils.Permission.CONTAINER;
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
 
 @Mixin(StorageMinecartEntity.class)
 public abstract class MixinStorageMinecartEntity extends AbstractMinecartEntity {
@@ -27,8 +26,8 @@ public abstract class MixinStorageMinecartEntity extends AbstractMinecartEntity 
     private void canPlayerUse(PlayerEntity player, CallbackInfoReturnable<Boolean> cir) {
         if (player instanceof ServerPlayerEntity serverPlayer) {
             EnclosureArea area = ServerMain.INSTANCE.getAllEnclosures((ServerWorld) this.getWorld()).getArea(getBlockPos());
-            if (area != null && !area.areaOf(getBlockPos()).hasPerm(serverPlayer, Permission.CONTAINER)) {
-                serverPlayer.sendMessage(CONTAINER.getNoPermissionMsg(serverPlayer));
+            if (area != null && !area.areaOf(getBlockPos()).hasPerm(serverPlayer, permissions.CONTAINER)) {
+                serverPlayer.sendMessage(permissions.CONTAINER.getNoPermissionMsg(serverPlayer));
                 cir.setReturnValue(false);
             }
         }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinTadpoleEntity.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinTadpoleEntity.java
@@ -1,7 +1,6 @@
 package com.github.zly2006.enclosure.mixin;
 
 import com.github.zly2006.enclosure.ServerMain;
-import com.github.zly2006.enclosure.utils.Permission;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.passive.TadpoleEntity;
@@ -14,6 +13,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
+
 @Mixin(TadpoleEntity.class)
 public abstract class MixinTadpoleEntity extends Entity {
     public MixinTadpoleEntity(EntityType<?> type, World world) {
@@ -22,10 +23,10 @@ public abstract class MixinTadpoleEntity extends Entity {
 
     @Inject(method = "interactMob", at = @At("HEAD"), cancellable = true)
     private void interactMob(PlayerEntity player, Hand hand, CallbackInfoReturnable<ActionResult> cir) {
-        if (ServerMain.INSTANCE.checkPermission(getWorld(), getBlockPos(), player, Permission.FISH)) {
+        if (ServerMain.INSTANCE.checkPermission(getWorld(), getBlockPos(), player, permissions.FISH)) {
             return;
         }
-        player.sendMessage(Permission.FISH.getNoPermissionMsg(player));
+        player.sendMessage(permissions.FISH.getNoPermissionMsg(player));
         cir.setReturnValue(ActionResult.FAIL);
     }
 }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinTntBlock.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinTntBlock.java
@@ -2,7 +2,6 @@ package com.github.zly2006.enclosure.mixin;
 
 import com.github.zly2006.enclosure.EnclosureArea;
 import com.github.zly2006.enclosure.ServerMain;
-import com.github.zly2006.enclosure.utils.Permission;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.TntBlock;
 import net.minecraft.entity.player.PlayerEntity;
@@ -20,24 +19,27 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
+
 @Mixin(TntBlock.class)
 public class MixinTntBlock {
     @Inject(method = "onUse", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/TntBlock;primeTnt(Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/entity/LivingEntity;)V"), cancellable = true)
     private void onUseInject(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand, BlockHitResult hit, CallbackInfoReturnable<ActionResult> cir) {
         if (player instanceof ServerPlayerEntity serverPlayer) {
             EnclosureArea area = ServerMain.INSTANCE.getSmallestEnclosure((ServerWorld) world, pos);
-            if (area != null && !area.hasPerm(serverPlayer, Permission.PRIME_TNT)) {
-                player.sendMessage(Permission.PRIME_TNT.getNoPermissionMsg(player));
+            if (area != null && !area.hasPerm(serverPlayer, permissions.PRIME_TNT)) {
+                player.sendMessage(permissions.PRIME_TNT.getNoPermissionMsg(player));
                 cir.setReturnValue(ActionResult.FAIL);
             }
         }
     }
+
     @Inject(method = "onProjectileHit", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/TntBlock;primeTnt(Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/entity/LivingEntity;)V"), cancellable = true)
     private void onProjectileHitInject(World world, BlockState state, BlockHitResult hit, ProjectileEntity projectile, CallbackInfo ci) {
         EnclosureArea area = ServerMain.INSTANCE.getSmallestEnclosure((ServerWorld) world, hit.getBlockPos());
         if (projectile.getOwner() instanceof ServerPlayerEntity player) {
-            if (area != null && !area.hasPerm(player, Permission.PRIME_TNT)) {
-                player.sendMessage(Permission.PRIME_TNT.getNoPermissionMsg(player));
+            if (area != null && !area.hasPerm(player, permissions.PRIME_TNT)) {
+                player.sendMessage(permissions.PRIME_TNT.getNoPermissionMsg(player));
                 ci.cancel();
             }
         }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinTntMinecartEntity.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinTntMinecartEntity.java
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import static com.github.zly2006.enclosure.utils.Permission.VEHICLE;
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
 
 @Mixin(TntMinecartEntity.class)
 public abstract class MixinTntMinecartEntity extends AbstractMinecartEntity {
@@ -21,7 +21,7 @@ public abstract class MixinTntMinecartEntity extends AbstractMinecartEntity {
 
     @Inject(method = "damage", at = @At("HEAD"), cancellable = true)
     private void onDamage(DamageSource source, float amount, CallbackInfoReturnable<Boolean> cir) {
-        if (!Utils.commonOnDamage(source, getBlockPos(), getWorld(), VEHICLE)) {
+        if (!Utils.commonOnDamage(source, getBlockPos(), getWorld(), permissions.VEHICLE)) {
             cir.setReturnValue(false);
         }
     }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinTurtleEggBlock.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinTurtleEggBlock.java
@@ -2,7 +2,6 @@ package com.github.zly2006.enclosure.mixin;
 
 import com.github.zly2006.enclosure.EnclosureArea;
 import com.github.zly2006.enclosure.ServerMain;
-import com.github.zly2006.enclosure.utils.Permission;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.TurtleEggBlock;
 import net.minecraft.entity.Entity;
@@ -15,13 +14,15 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
+
 @Mixin(TurtleEggBlock.class)
 public class MixinTurtleEggBlock {
     @Inject(method = "tryBreakEgg", at = @At("HEAD"), cancellable = true)
     private void onBreakEgg(World world, BlockState state, BlockPos pos, Entity entity, int inverseChance, CallbackInfo ci) {
         if (!world.isClient && entity instanceof ServerPlayerEntity player) {
             EnclosureArea area = ServerMain.INSTANCE.getAllEnclosures((ServerWorld) world).getArea(pos);
-            if (area != null && !area.areaOf(pos).hasPerm(player, Permission.BREAK_TURTLE_EGG)) {
+            if (area != null && !area.areaOf(pos).hasPerm(player, permissions.BREAK_TURTLE_EGG)) {
                 ci.cancel();
             }
         }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinWitherEntity.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinWitherEntity.java
@@ -2,7 +2,6 @@ package com.github.zly2006.enclosure.mixin;
 
 import com.github.zly2006.enclosure.EnclosureArea;
 import com.github.zly2006.enclosure.ServerMain;
-import com.github.zly2006.enclosure.utils.Permission;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
@@ -15,6 +14,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
 
 @Mixin(WitherEntity.class)
 public abstract class MixinWitherEntity extends Entity {
@@ -29,11 +30,12 @@ public abstract class MixinWitherEntity extends Entity {
         }
         EnclosureArea a = ServerMain.INSTANCE.getSmallestEnclosure((ServerWorld) getWorld(), blockPos);
         if (a == null) return;
-        if (!a.hasPubPerm(Permission.WITHER_DESTROY)) {
+        if (!a.hasPubPerm(permissions.WITHER_DESTROY)) {
             // prevent breaking block
             ci.cancel();
         }
     }
+
     @Inject(method = "mobTick", at = @At("HEAD"), cancellable = true)
     private void onTick(CallbackInfo ci) {
         if (getWorld().isClient) {
@@ -41,7 +43,7 @@ public abstract class MixinWitherEntity extends Entity {
         }
         EnclosureArea a = ServerMain.INSTANCE.getSmallestEnclosure((ServerWorld) getWorld(), getBlockPos());
         if (a == null) return;
-        if (!a.hasPubPerm(Permission.WITHER_ENTER)) {
+        if (!a.hasPubPerm(permissions.WITHER_ENTER)) {
             // prevent entering enclosure
             discard();
             ci.cancel();

--- a/src/main/java/com/github/zly2006/enclosure/mixin/MixinWitherSkullBlock.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/MixinWitherSkullBlock.java
@@ -3,7 +3,6 @@ package com.github.zly2006.enclosure.mixin;
 import com.github.zly2006.enclosure.EnclosureArea;
 import com.github.zly2006.enclosure.EnclosureList;
 import com.github.zly2006.enclosure.ServerMain;
-import com.github.zly2006.enclosure.utils.Permission;
 import net.minecraft.block.WitherSkullBlock;
 import net.minecraft.block.entity.SkullBlockEntity;
 import net.minecraft.server.world.ServerWorld;
@@ -14,6 +13,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
+
 @Mixin(WitherSkullBlock.class)
 public class MixinWitherSkullBlock {
     @Inject(at = @At("HEAD"), method = "onPlaced(Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/entity/SkullBlockEntity;)V", cancellable = true)
@@ -23,7 +24,7 @@ public class MixinWitherSkullBlock {
         }
         EnclosureList list = ServerMain.INSTANCE.getAllEnclosures((ServerWorld) world);
         EnclosureArea a = list.getArea(pos);
-        if (a != null && !a.areaOf(pos).hasPubPerm(Permission.WITHER_SPAWN)) {
+        if (a != null && !a.areaOf(pos).hasPubPerm(permissions.WITHER_SPAWN)) {
             ci.cancel();
         }
     }

--- a/src/main/java/com/github/zly2006/enclosure/mixin/workaround/MixinServerPlayNetworkHandler.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/workaround/MixinServerPlayNetworkHandler.java
@@ -20,7 +20,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
  */
 @Mixin(ServerPlayNetworkHandler.class)
 public class MixinServerPlayNetworkHandler {
-    @Shadow public ServerPlayerEntity player;
+    @Shadow
+    public ServerPlayerEntity player;
 
     public MixinServerPlayNetworkHandler(ServerPlayerEntity player) {
         this.player = player;

--- a/src/main/java/com/github/zly2006/enclosure/mixin/workaround/MixinServerPlayerInteractionManager.java
+++ b/src/main/java/com/github/zly2006/enclosure/mixin/workaround/MixinServerPlayerInteractionManager.java
@@ -11,6 +11,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(ServerPlayerInteractionManager.class)
 public abstract class MixinServerPlayerInteractionManager implements MiningStatusAccess {
     boolean miningSuccess = false;
+
     @Inject(method = "method_41250", at = @At("HEAD"))
     private void afterBreakingBlock(BlockPos pos, boolean success, int sequence, String reason, CallbackInfo ci) {
         miningSuccess = success;

--- a/src/main/java/com/github/zly2006/enclosure/network/ConfirmRequestS2CPacket.java
+++ b/src/main/java/com/github/zly2006/enclosure/network/ConfirmRequestS2CPacket.java
@@ -1,7 +1,7 @@
 package com.github.zly2006.enclosure.network;
 
+import com.github.zly2006.enclosure.gui.ConfirmScreen;
 import com.github.zly2006.enclosure.gui.EnclosureGui;
-import com.github.zly2006.enclosure.gui.*;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
 import net.fabricmc.fabric.api.networking.v1.PacketSender;

--- a/src/main/java/com/github/zly2006/enclosure/network/EnclosureInstalledC2SPacket.java
+++ b/src/main/java/com/github/zly2006/enclosure/network/EnclosureInstalledC2SPacket.java
@@ -71,6 +71,7 @@ public class EnclosureInstalledC2SPacket implements ServerPlayNetworking.PlayCha
             } else {
                 player.sendMessage(Text.translatable("enclosure.message.outdated", MOD_VERSION.getFriendlyString(), version.getFriendlyString()), false);
             }
-        } catch (VersionParsingException ignored) { }
+        } catch (VersionParsingException ignored) {
+        }
     }
 }

--- a/src/main/java/com/github/zly2006/enclosure/network/RequestOpenScreenC2SPPacket.java
+++ b/src/main/java/com/github/zly2006/enclosure/network/RequestOpenScreenC2SPPacket.java
@@ -61,8 +61,7 @@ public class RequestOpenScreenC2SPPacket implements ServerPlayNetworking.PlayCha
                     return;
                 }
                 area = area.areaOf(blockPos);
-            }
-            else {
+            } else {
                 area = ServerMain.INSTANCE.getEnclosure(name);
                 if (area == null) {
                     player.sendMessage(TrT.of("enclosure.message.no_enclosure"));

--- a/src/main/java/com/github/zly2006/enclosure/network/SyncPermissionS2CPacket.java
+++ b/src/main/java/com/github/zly2006/enclosure/network/SyncPermissionS2CPacket.java
@@ -14,6 +14,7 @@ public class SyncPermissionS2CPacket implements ClientPlayNetworking.PlayChannel
     public static void register() {
         ClientPlayNetworking.registerGlobalReceiver(NetworkChannels.SYNC_PERMISSION, new SyncPermissionS2CPacket());
     }
+
     @Override
     public void receive(MinecraftClient client, ClientPlayNetworkHandler handler, PacketByteBuf buf, PacketSender responseSender) {
         UUID uuid = buf.readUuid();

--- a/src/main/java/com/github/zly2006/enclosure/network/SyncSelectionS2CPacket.java
+++ b/src/main/java/com/github/zly2006/enclosure/network/SyncSelectionS2CPacket.java
@@ -13,7 +13,8 @@ import net.minecraft.util.math.BlockPos;
 
 @Environment(EnvType.CLIENT)
 public class SyncSelectionS2CPacket implements ClientPlayNetworking.PlayChannelHandler {
-    private SyncSelectionS2CPacket() {}
+    private SyncSelectionS2CPacket() {
+    }
 
     public static void register() {
         ClientPlayNetworking.registerGlobalReceiver(NetworkChannels.SYNC_SELECTION, new SyncSelectionS2CPacket());

--- a/src/main/java/com/github/zly2006/enclosure/network/UUIDCacheS2CPacket.java
+++ b/src/main/java/com/github/zly2006/enclosure/network/UUIDCacheS2CPacket.java
@@ -16,6 +16,7 @@ import static com.github.zly2006.enclosure.ServerMainKt.LOGGER;
 
 public class UUIDCacheS2CPacket implements ClientPlayNetworking.PlayChannelHandler {
     public static final Map<UUID, String> uuid2name = new HashMap<>();
+
     public static String getName(UUID uuid) {
         if (uuid2name.containsKey(uuid)) {
             return uuid2name.get(uuid);
@@ -23,7 +24,9 @@ public class UUIDCacheS2CPacket implements ClientPlayNetworking.PlayChannelHandl
         return uuid.toString();
     }
 
-    private UUIDCacheS2CPacket() {}
+    private UUIDCacheS2CPacket() {
+    }
+
     @Override
     public void receive(MinecraftClient client, ClientPlayNetworkHandler handler, PacketByteBuf buf, PacketSender responseSender) {
         NbtCompound compound = buf.readNbt();

--- a/src/main/java/com/github/zly2006/enclosure/utils/ResourceLoader.java
+++ b/src/main/java/com/github/zly2006/enclosure/utils/ResourceLoader.java
@@ -6,7 +6,8 @@ import java.io.InputStream;
 public class ResourceLoader {
     private static final String LANGUAGE_FILES_PATH = "/assets/enclosure/lang/";
 
-    public ResourceLoader(){}
+    public ResourceLoader() {
+    }
 
     public static String getLanguageFile(String langCode) throws IOException {
         try (InputStream resource = ResourceLoader.class.getResourceAsStream(LANGUAGE_FILES_PATH + langCode + ".json")) {

--- a/src/main/java/com/github/zly2006/enclosure/utils/Serializable2Text.java
+++ b/src/main/java/com/github/zly2006/enclosure/utils/Serializable2Text.java
@@ -13,6 +13,7 @@ public interface Serializable2Text {
         Full,
         BarredFull,
     }
+
     static Serializable2Text of(MutableText text) {
         return (settings, player) -> text;
     }

--- a/src/main/java/com/github/zly2006/enclosure/utils/Utils.java
+++ b/src/main/java/com/github/zly2006/enclosure/utils/Utils.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static com.github.zly2006.enclosure.ServerMainKt.minecraftServer;
+import static com.github.zly2006.enclosure.utils.Permission.permissions;
 
 public class Utils {
     public static boolean isAnimal(Entity entity) {
@@ -157,16 +158,13 @@ public class Utils {
 
     public static boolean commonOnDamage(DamageSource source, Entity entity) {
         if (isAnimal(entity)) {
-            return commonOnDamage(source, entity.getBlockPos(), entity.getWorld(), Permission.ATTACK_ANIMAL);
-        }
-        else if (isMonster(entity)) {
-            return commonOnDamage(source, entity.getBlockPos(), entity.getWorld(), Permission.ATTACK_MONSTER);
-        }
-        else if (entity instanceof VillagerEntity) {
-            return commonOnDamage(source, entity.getBlockPos(), entity.getWorld(), Permission.ATTACK_VILLAGER);
-        }
-        else {
-            return commonOnDamage(source, entity.getBlockPos(), entity.getWorld(), Permission.ATTACK_ENTITY);
+            return commonOnDamage(source, entity.getBlockPos(), entity.getWorld(), permissions.ATTACK_ANIMAL);
+        } else if (isMonster(entity)) {
+            return commonOnDamage(source, entity.getBlockPos(), entity.getWorld(), permissions.ATTACK_MONSTER);
+        } else if (entity instanceof VillagerEntity) {
+            return commonOnDamage(source, entity.getBlockPos(), entity.getWorld(), permissions.ATTACK_VILLAGER);
+        } else {
+            return commonOnDamage(source, entity.getBlockPos(), entity.getWorld(), permissions.ATTACK_ENTITY);
         }
     }
 

--- a/src/main/kotlin/com/github/zly2006/enclosure/EnclosureArea.kt
+++ b/src/main/kotlin/com/github/zly2006/enclosure/EnclosureArea.kt
@@ -5,6 +5,7 @@ import com.github.zly2006.enclosure.command.Session
 import com.github.zly2006.enclosure.gui.EnclosureScreenHandler
 import com.github.zly2006.enclosure.network.NetworkChannels
 import com.github.zly2006.enclosure.utils.*
+import com.github.zly2006.enclosure.utils.Permission.Companion.permissions
 import com.github.zly2006.enclosure.utils.Serializable2Text.SerializationSettings
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking
@@ -126,7 +127,7 @@ open class EnclosureArea : PersistentState, EnclosureView {
         owner = session.owner
         this.name = name
         permissionsMap[owner] = mutableMapOf()
-        Permission.PERMISSIONS.values.filter { p -> p.target.fitPlayer() }
+        permissions.PERMISSIONS.values.filter { p -> p.target.fitPlayer() }
             .forEach { p -> permissionsMap[owner]!![p] = true }
         minX = min(session.pos1.x, session.pos2.x)
         minY = min(session.pos1.y, session.pos2.y)
@@ -250,7 +251,7 @@ open class EnclosureArea : PersistentState, EnclosureView {
         return if (source.player != null) {
             source.player!!.uuid == owner || hasPerm(
                 source.player!!.uuid,
-                Permission.ADMIN
+                permissions.ADMIN
             )
         } else {
             false
@@ -265,7 +266,7 @@ open class EnclosureArea : PersistentState, EnclosureView {
 
     override fun setPermission(source: ServerCommandSource?, uuid: UUID, perm: Permission, value: Boolean?) {
         checkLock()
-        if (source != null && source.player != null && !hasPerm(source.player!!, Permission.ADMIN)) {
+        if (source != null && source.player != null && !hasPerm(source.player!!, permissions.ADMIN)) {
             LOGGER.warn("Player " + source.name + " try to set permission of " + uuid + " in " + name + " without admin permission")
             LOGGER.warn("allowing, if you have any problem please report to the author")
         }

--- a/src/main/kotlin/com/github/zly2006/enclosure/PermissionHolder.kt
+++ b/src/main/kotlin/com/github/zly2006/enclosure/PermissionHolder.kt
@@ -3,6 +3,7 @@ package com.github.zly2006.enclosure
 import com.github.zly2006.enclosure.command.CONSOLE
 import com.github.zly2006.enclosure.exceptions.PermissionTargetException
 import com.github.zly2006.enclosure.utils.*
+import com.github.zly2006.enclosure.utils.Permission.Companion.permissions
 import com.github.zly2006.enclosure.utils.Serializable2Text.SerializationSettings
 import com.mojang.datafixers.util.Pair
 import net.minecraft.server.command.ServerCommandSource
@@ -26,7 +27,7 @@ interface PermissionHolder : Serializable2Text {
         if (checkPermission(player, "enclosure.bypass") && perm.canBypass) {
             return true
         }
-        return if (perm === Permission.ADMIN && isOwnerOrFatherAdmin(player.commandSource)) {
+        return if (perm === permissions.ADMIN && isOwnerOrFatherAdmin(player.commandSource)) {
             true
         } else hasPerm(player.uuid, perm)
     }

--- a/src/main/kotlin/com/github/zly2006/enclosure/mixinadatper/MixinHopper.kt
+++ b/src/main/kotlin/com/github/zly2006/enclosure/mixinadatper/MixinHopper.kt
@@ -1,6 +1,7 @@
 package com.github.zly2006.enclosure.mixinadatper
 
 import com.github.zly2006.enclosure.utils.Permission
+import com.github.zly2006.enclosure.utils.Permission.Companion.permissions
 import com.github.zly2006.enclosure.utils.contains
 import com.github.zly2006.enclosure.utils.getEnclosure
 import net.minecraft.block.entity.BlockEntity
@@ -25,7 +26,7 @@ fun canExtractFromInventory(
         else -> return true
     } as? ServerWorld ?: return true
     val area = world.getEnclosure(pos)
-    if (area?.hasPubPerm(Permission.CONTAINER) == false) { // null means no enclosure, allow access
+    if (area?.hasPubPerm(permissions.CONTAINER) == false) { // null means no enclosure, allow access
         val box = when (hopper) {
             is BlockEntity -> Box(hopper.pos)
             is Entity -> hopper.boundingBox

--- a/src/main/kotlin/com/github/zly2006/enclosure/mixinadatper/MixinPistonBlock.kt
+++ b/src/main/kotlin/com/github/zly2006/enclosure/mixinadatper/MixinPistonBlock.kt
@@ -2,6 +2,7 @@ package com.github.zly2006.enclosure.mixinadatper
 
 import com.github.zly2006.enclosure.ServerMain
 import com.github.zly2006.enclosure.utils.Permission
+import com.github.zly2006.enclosure.utils.Permission.Companion.permissions
 import com.github.zly2006.enclosure.utils.mark4updateChecked
 import net.minecraft.block.piston.PistonHandler
 import net.minecraft.server.world.ServerWorld
@@ -24,7 +25,7 @@ fun protectPiston(
     val areas = positions.map { ServerMain.getSmallestEnclosure(world, it) }
         .map { Optional.ofNullable(it) } // null is also considered as an "area"
         .distinct()
-    val cancel = areas.size > 1 && areas.mapNotNull { it.getOrNull()?.hasPubPerm(Permission.PISTON)?.not() }.any { it }
+    val cancel = areas.size > 1 && areas.mapNotNull { it.getOrNull()?.hasPubPerm(permissions.PISTON)?.not() }.any { it }
     if (cancel) {
         positions.forEach(world::mark4updateChecked) // some position may be invalid
         cir.returnValue = false

--- a/src/main/kotlin/com/github/zly2006/enclosure/utils/Permission.kt
+++ b/src/main/kotlin/com/github/zly2006/enclosure/utils/Permission.kt
@@ -90,6 +90,10 @@ class Permission(
     }
 
     companion object {
+        lateinit var permissions: Permissions
+    }
+
+    class Permissions{
         @JvmField val PERMISSIONS: MutableMap<String, Permission> = mutableMapOf()
         // Special permissions
         @JvmField val ADMIN = Permission("admin", Target.Player, false, Items.COMMAND_BLOCK)


### PR DESCRIPTION
当使用自制整合包时（因为整合包内容较多所以无法确定是哪个mod导致的），游戏在窗口出现前闪退，日志如下：

[2024-04-23-3.log](https://github.com/zly2006/Enclosure/files/15072443/2024-04-23-3.log)

问题的原因是kotlin的companion object不知道为什么提前调用了还没有加载的"net.minecraft.item.Items"的static变量

文件位置：https://github.com/zly2006/Enclosure/blob/ef122ce8004dc5be4fdf5e34429b2173f4e2b208/src/main/kotlin/com/github/zly2006/enclosure/utils/Permission.kt

通过将companion object的内容移动到新创建的[Permissions](https://github.com/fabric-of-tetrahedron/Enclosure/blob/b8e46b38a867d3eefce7a90c7f38147e3d42dd1e/src/main/kotlin/com/github/zly2006/enclosure/utils/Permission.kt#L96)类中（并且修改了所有对于这些static内容的调用），并将这个对象的初始化搬到[ServerMain](https://github.com/fabric-of-tetrahedron/Enclosure/blob/b8e46b38a867d3eefce7a90c7f38147e3d42dd1e/src/main/kotlin/com/github/zly2006/enclosure/ServerMain.kt#L369)中，问题得以解决

我知道这种bug大概比较难排查，我刚开始写mod，不太懂mc fabric的生命周期设计，这个修复仅供参考