### PR TITLE
perf: improve performance of getSmallestEnclosure

### DIFF
--- a/src/main/java/com/github/zly2006/enclosure/EnclosureList.kt
+++ b/src/main/java/com/github/zly2006/enclosure/EnclosureList.kt
@@ -13,7 +13,8 @@ import net.minecraft.world.PersistentState
 class EnclosureList(world: ServerWorld, isRoot: Boolean) : PersistentState() {
     private val areaMap: MutableMap<String, EnclosureArea> = HashMap()
     private val boundWorld: ServerWorld?
-    val areas = areaMap.values
+    var areas: List<EnclosureArea> = listOf()
+        private set
 
     constructor(nbt: NbtCompound, world: ServerWorld, isRoot: Boolean) : this(world, isRoot) {
         (nbt[ENCLOSURE_LIST_KEY] as? NbtList)?.forEach {
@@ -25,6 +26,8 @@ class EnclosureList(world: ServerWorld, isRoot: Boolean) : PersistentState() {
                 areaMap[name] = EnclosureArea(compound, world)
             }
         }
+
+        updateAreasList()
     }
 
     init {
@@ -75,6 +78,7 @@ class EnclosureList(world: ServerWorld, isRoot: Boolean) : PersistentState() {
     fun remove(name: String): Boolean {
         if (areaMap.containsKey(name)) {
             areaMap.remove(name)
+            updateAreasList()
             markDirty()
             return true
         }
@@ -83,7 +87,13 @@ class EnclosureList(world: ServerWorld, isRoot: Boolean) : PersistentState() {
 
     fun addArea(area: EnclosureArea) {
         areaMap[area.name] = area
+        updateAreasList()
         markDirty()
+    }
+
+    // 添加和删除操作一般很少，慢一点无所谓
+    private fun updateAreasList() {
+        areas = areaMap.values.toList()
     }
 }
 

--- a/src/main/kotlin/com/github/zly2006/enclosure/EnclosureArea.kt
+++ b/src/main/kotlin/com/github/zly2006/enclosure/EnclosureArea.kt
@@ -50,12 +50,13 @@ open class EnclosureArea : PersistentState, EnclosureView {
     }
 
     private var locked = false
-    final override var minX by lockChecker(0)
-    final override var minY by lockChecker(0)
-    final override var minZ by lockChecker(0)
-    final override var maxX by lockChecker(0)
-    final override var maxY by lockChecker(0)
-    final override var maxZ by lockChecker(0)
+    // removed lockChecker due to performance issues
+    final override var minX = 0
+    final override var minY = 0
+    final override var minZ = 0
+    final override var maxX = 0
+    final override var maxY = 0
+    final override var maxZ = 0
     var world: ServerWorld
         protected set
     final override var name = ""

--- a/src/main/kotlin/com/github/zly2006/enclosure/ServerMain.kt
+++ b/src/main/kotlin/com/github/zly2006/enclosure/ServerMain.kt
@@ -302,7 +302,6 @@ object ServerMain: ModInitializer {
     fun getSmallestEnclosure(world: ServerWorld, pos: BlockPos?): EnclosureArea? {
         return enclosures[world.registryKey]!!.areas
             .firstOrNull { area: EnclosureArea -> area.isInner(pos!!) }
-            ?.areaOf(pos!!)
     }
 
     fun checkPermission(player: ServerPlayerEntity, permission: Permission, pos: BlockPos): Boolean {


### PR DESCRIPTION
# Motivation

![image](https://github.com/zly2006/Enclosure/assets/42467154/db7fecc4-aa50-411f-9093-ec68f2fe8a03)
Though not on every tick, still a significant impact on MSPT. 

# Benchmark

Look up 1,000,000 random positions with enclosures data in our 1.21 server.

Code:
```kotlin
dispatcher.register(
    CommandManager.literal("bench")
        .executes {
            val posList: MutableList<BlockPos> = ArrayList(1000000)
            val random = Random()
            for (i in 1..1000000) {
                val x = random.nextInt(-1000, 1001)
                val z = random.nextInt(-1000, 1001)
                val y = random.nextInt(-10, 101)
                posList.add(BlockPos(x, y, z))
            }

            val time = measureTimeMillis {
                for (pos in posList) {
                    getSmallestEnclosure(it.source.world, pos)
                }
            }

            it.source.sendMessage(Text.literal("Time elapsed: $time ms"))
            1
        }
)
```

Result (10 tests each):
```
before          (ms): 666 650 650 628 628 627 656 642 649 659
after(w/ locks) (ms): 388 398 388 321 364 408 336 357 364 333
after(w/o locks)(ms): 151 125 138 136 137 145 131 132 132 135
```

# Changes

HashMap.values iterations is slow so used a list to cache the areas

Also removed the lockChecker for coordinates as it is not used. Possible reason: https://stackoverflow.com/questions/39152264/kotlin-how-can-i-avoid-autoboxing-garbage-in-delegated-properties but I can't fix the problem with the code in the link